### PR TITLE
feat: auto-focus terminal when selecting a session

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -1734,6 +1734,7 @@ public partial class MainWindow : Window
             var edited = dialog.EditedSettings;
             _vm.Settings.AutoRestoreSessions = edited.AutoRestoreSessions;
             _vm.Settings.AutoResumeClaude = edited.AutoResumeClaude;
+            _vm.Settings.AutoFocusTerminalOnSelect = edited.AutoFocusTerminalOnSelect;
             _vm.Settings.ShowToastNotifications = edited.ShowToastNotifications;
             _vm.Settings.ShowNotificationSound = edited.ShowNotificationSound;
             _vm.Settings.AnthropicApiKey = edited.AnthropicApiKey;

--- a/src/CodeShellManager/Models/AppState.cs
+++ b/src/CodeShellManager/Models/AppState.cs
@@ -6,6 +6,7 @@ public class AppSettings
 {
     public bool AutoRestoreSessions { get; set; } = true;
     public bool AutoResumeClaude { get; set; } = true;
+    public bool AutoFocusTerminalOnSelect { get; set; } = true;
     public bool ShowToastNotifications { get; set; } = false;
     public bool ShowNotificationSound { get; set; } = false;
     public string AnthropicApiKey { get; set; } = "";

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -292,7 +292,15 @@ public sealed class TerminalBridge : IDisposable
         if (!_ready) return;
         WpfApplication.Current?.Dispatcher.BeginInvoke(() =>
         {
-            try { _webView.CoreWebView2?.PostWebMessageAsString("{\"type\":\"focus\"}"); }
+            try
+            {
+                // Move WPF keyboard focus onto the WebView2 host. Without this, focus
+                // can stay on whichever WPF control was last clicked (e.g. a sidebar
+                // item Border), so the JS term.focus() below has no effect at the
+                // WPF level and typing goes nowhere.
+                _webView.Focus();
+                _webView.CoreWebView2?.PostWebMessageAsString("{\"type\":\"focus\"}");
+            }
             catch { }
         });
     }

--- a/src/CodeShellManager/ViewModels/MainViewModel.cs
+++ b/src/CodeShellManager/ViewModels/MainViewModel.cs
@@ -153,7 +153,8 @@ public partial class MainViewModel : ObservableObject
     {
         ActiveSession = vm;
         vm.ClearAlert();
-        vm.Bridge?.FocusTerminal();
+        if (Settings.AutoFocusTerminalOnSelect)
+            vm.Bridge?.FocusTerminal();
         vm.AlertDetector?.NotifyUserInteracted();
         OnPropertyChanged(nameof(AlertCount));
     }

--- a/src/CodeShellManager/Views/SettingsWindow.xaml
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml
@@ -208,6 +208,9 @@
                 <CheckBox x:Name="AutoResumeClaudeCheck" Content="Auto-resume Claude sessions on restore"
                           Margin="0,4,0,0"
                           ToolTip="When restoring sessions, append --resume &lt;sessionId&gt; to claude commands so Claude picks up the previous conversation."/>
+                <CheckBox x:Name="AutoFocusTerminalOnSelectCheck" Content="Auto-focus terminal when selecting a session"
+                          Margin="0,4,0,0"
+                          ToolTip="When clicking a session in the sidebar (or cycling with Ctrl+Tab), move keyboard focus into the terminal so you can start typing immediately."/>
 
                 <!-- Appearance -->
                 <TextBlock Text="APPEARANCE" Style="{StaticResource SectionHeader}"/>

--- a/src/CodeShellManager/Views/SettingsWindow.xaml.cs
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml.cs
@@ -43,6 +43,7 @@ public partial class SettingsWindow : Window
             TerminalLineHeight = current.TerminalLineHeight,
             IndexTerminalOutput = current.IndexTerminalOutput,
             OutputRetentionDays = current.OutputRetentionDays,
+            LaunchCommands = current.LaunchCommands.ToList(),
         };
 
         // Populate controls

--- a/src/CodeShellManager/Views/SettingsWindow.xaml.cs
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml.cs
@@ -24,6 +24,7 @@ public partial class SettingsWindow : Window
         {
             AutoRestoreSessions = current.AutoRestoreSessions,
             AutoResumeClaude = current.AutoResumeClaude,
+            AutoFocusTerminalOnSelect = current.AutoFocusTerminalOnSelect,
             ShowToastNotifications = current.ShowToastNotifications,
             ShowNotificationSound = current.ShowNotificationSound,
             AnthropicApiKey = current.AnthropicApiKey,
@@ -48,6 +49,7 @@ public partial class SettingsWindow : Window
         DefaultFolderBox.Text = _edited.DefaultWorkingFolder;
         AutoRestoreCheck.IsChecked = _edited.AutoRestoreSessions;
         AutoResumeClaudeCheck.IsChecked = _edited.AutoResumeClaude;
+        AutoFocusTerminalOnSelectCheck.IsChecked = _edited.AutoFocusTerminalOnSelect;
         ShowToastCheck.IsChecked = _edited.ShowToastNotifications;
         ShowNotificationSoundCheck.IsChecked = _edited.ShowNotificationSound;
         ShowGitBranchCheck.IsChecked = _edited.ShowGitBranch;
@@ -109,6 +111,7 @@ public partial class SettingsWindow : Window
         _edited.DefaultWorkingFolder = DefaultFolderBox.Text.Trim();
         _edited.AutoRestoreSessions = AutoRestoreCheck.IsChecked == true;
         _edited.AutoResumeClaude = AutoResumeClaudeCheck.IsChecked == true;
+        _edited.AutoFocusTerminalOnSelect = AutoFocusTerminalOnSelectCheck.IsChecked == true;
         _edited.ShowToastNotifications = ShowToastCheck.IsChecked == true;
         _edited.ShowNotificationSound = ShowNotificationSoundCheck.IsChecked == true;
         _edited.ShowGitBranch = ShowGitBranchCheck.IsChecked == true;


### PR DESCRIPTION
Closes #13.

## Summary
- Sidebar click (and `Ctrl+Tab` cycling) now moves keyboard focus into the selected session's terminal so the user can start typing immediately.
- `TerminalBridge.FocusTerminal()` now calls `_webView.Focus()` in addition to posting the JS focus message — without this, WPF keyboard focus stays on the clicked sidebar Border and the JS `term.focus()` has no effect at the WPF level.
- New `AppSettings.AutoFocusTerminalOnSelect` (default `true`) gates the focus call inside `MainViewModel.FocusSession`, surfaced as a checkbox in the Settings window under SESSION SETTINGS. When disabled, `ActiveSession` and the active-terminal highlight still update; only the focus jump is skipped.

## Test plan
- [ ] Click a session in the sidebar → caret blinks in that session's terminal, typing reaches the CLI without an extra click.
- [ ] `Ctrl+Tab` and `Ctrl+Shift+Tab` cycle sessions and focus follows.
- [ ] Toggle "Auto-focus terminal when selecting a session" off in Settings → clicking another session changes the active-terminal highlight but keyboard focus stays where it was.
- [ ] Re-enable the setting → behaviour returns to focus-on-select.
- [ ] Setting persists across app restart (`state.json`).
- [ ] Alt+Tab back into the app still refocuses the active terminal (regression check on `OnWindowActivated`).