### PR TITLE
ci: publish signed MSI to winget on release

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,34 @@
+name: Publish to WinGet
+
+# Submits the signed MSI from a GitHub Release to microsoft/winget-pkgs.
+# - `release` event fires automatically when CI / Release publishes the GitHub Release.
+# - `workflow_dispatch` lets us re-publish a past version (used for the very first
+#   submission once this workflow exists on main).
+#
+# Requires repo secret WINGET_TOKEN: a classic PAT with `public_repo` scope.
+# (winget-releaser does not yet support fine-grained tokens.)
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.4.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: UmageAI.CodeShellManager
+          installers-regex: '\.msi$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,8 @@ git push origin v1.2.3
 
 The tag value overrides the csproj `<Version>` at publish time (`-p:Version=` flag). **Do not rely on the csproj version number** — bump it for local build clarity only. CI produces a signed exe, MSI installer, and portable ZIP, then creates a GitHub Release automatically.
 
+A second workflow, `.github/workflows/winget.yml`, fires on the `release: released` event and submits the signed MSI to microsoft/winget-pkgs as `UmageAI.CodeShellManager` via [vedantmgoyal9/winget-releaser](https://github.com/vedantmgoyal9/winget-releaser). It needs the repo secret `WINGET_TOKEN` (classic PAT, `public_repo` scope). The same workflow is `workflow_dispatch`-able with a `tag` input to backfill or retry a release.
+
 ## Known Conventions
 
 - All WPF color literals use Catppuccin Mocha hex values — do not introduce system colors


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/winget.yml` submits the signed MSI to microsoft/winget-pkgs as `UmageAI.CodeShellManager` after each release.
- Triggers on `release: released` (auto) and `workflow_dispatch` with a `tag` input (manual backfill / retry).
- Uses [vedantmgoyal9/winget-releaser@v2](https://github.com/vedantmgoyal9/winget-releaser).

## Requires before this works
- Repo secret `WINGET_TOKEN` — a classic GitHub PAT with `public_repo` scope. Fine-grained tokens are not yet supported by the action.

## Backfilling v0.4.0
v0.4.0 was released before this workflow existed, so the `release` event won't fire for it. Once the secret is set, dispatch the workflow manually:
\`\`\`
gh workflow run winget.yml -f tag=v0.4.0
\`\`\`
The action submits a PR to microsoft/winget-pkgs; review/merge happens on Microsoft's side and typically lands within a day.

## Test plan
- [ ] Add `WINGET_TOKEN` secret in repo settings
- [ ] Manually dispatch with `tag=v0.4.0` to seed the package on winget-pkgs
- [ ] Confirm Microsoft's bot accepts the PR
- [ ] On next tagged release, verify the workflow fires automatically and submits the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)