### PR TITLE
fix: ConPTY stdio leak, profile font CSS, xterm cell seams

### DIFF
--- a/src/CodeShellManager/App.xaml.cs
+++ b/src/CodeShellManager/App.xaml.cs
@@ -1,9 +1,25 @@
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace CodeShellManager;
 
 public partial class App : System.Windows.Application
 {
+    // When the WPF app is launched from a parent that hands us redirected std
+    // handles (dotnet run, bash, cmd with redirection), ConPTY children inherit
+    // those handles and bleed their output to the parent — bypassing the PTY
+    // entirely and leaving xterm.js with no output. Detaching the console and
+    // clearing std handles at startup prevents the leak.
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool FreeConsole();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetStdHandle(int nStdHandle, System.IntPtr handle);
+
+    private const int STD_INPUT_HANDLE = -10;
+    private const int STD_OUTPUT_HANDLE = -11;
+    private const int STD_ERROR_HANDLE = -12;
+
     public static System.Windows.Forms.NotifyIcon? TrayIcon { get; private set; }
 
     /// <summary>
@@ -20,6 +36,13 @@ public partial class App : System.Windows.Application
     protected override void OnStartup(System.Windows.StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        // Detach from any inherited parent console / std handles so ConPTY
+        // children can't bleed their output back to the launching shell.
+        FreeConsole();
+        SetStdHandle(STD_INPUT_HANDLE,  System.IntPtr.Zero);
+        SetStdHandle(STD_OUTPUT_HANDLE, System.IntPtr.Zero);
+        SetStdHandle(STD_ERROR_HANDLE,  System.IntPtr.Zero);
 
         CleanStart = e.Args.Any(a =>
             string.Equals(a, "--clean", System.StringComparison.OrdinalIgnoreCase));

--- a/src/CodeShellManager/Assets/terminal-init.js
+++ b/src/CodeShellManager/Assets/terminal-init.js
@@ -19,6 +19,9 @@
     },
     scrollback: 5000,
     allowProposedApi: true,
+    // Render box-drawing and block characters with built-in glyphs so they
+    // tile flush across cells — the font's own glyphs leave thin seams.
+    customGlyphs: true,
     // Ctrl+C/V handled via customKeyEventHandler below. Ctrl+Shift+C/V also work.
     macOptionIsMeta: false,
     windowsMode: true,   // correct line ending handling on Windows

--- a/src/CodeShellManager/Services/WindowsTerminalProfileService.cs
+++ b/src/CodeShellManager/Services/WindowsTerminalProfileService.cs
@@ -196,7 +196,8 @@ public static class WindowsTerminalProfileService
             return null;
         }
 
-        string? face = Pick("font", "face") is { ValueKind: JsonValueKind.String } f ? f.GetString() : null;
+        string? face = Pick("font", "face") is { ValueKind: JsonValueKind.String } f
+            ? QuoteFontFace(f.GetString()) : null;
         int? size = Pick("font", "size") is { ValueKind: JsonValueKind.Number } s && s.TryGetInt32(out var iv) ? iv : null;
         string? weight = Pick("font", "weight") switch
         {
@@ -220,5 +221,17 @@ public static class WindowsTerminalProfileService
         if (string.IsNullOrEmpty(dir)) return "";
         if (dir.StartsWith("~")) dir = "%USERPROFILE%" + dir[1..];
         return Environment.ExpandEnvironmentVariables(dir);
+    }
+
+    // WT stores font face as a bare name ("0xProto Nerd Font"). xterm drops it
+    // straight into CSS font-family, where unquoted names containing spaces fail
+    // to resolve. Quote and append a monospace fallback so missing fonts still
+    // render legibly.
+    private static string? QuoteFontFace(string? face)
+    {
+        if (string.IsNullOrWhiteSpace(face)) return null;
+        face = face.Trim();
+        if (face.StartsWith('\'') || face.StartsWith('"')) return face;
+        return $"'{face}', monospace";
     }
 }

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -278,7 +278,7 @@ public sealed class TerminalBridge : IDisposable
         if (!HasAnyOverride(session)) return;
 
         var opts = new System.Collections.Generic.Dictionary<string, object?>();
-        if (session.ProfileFontFamily    != null) opts["fontFamily"]    = session.ProfileFontFamily;
+        if (session.ProfileFontFamily    != null) opts["fontFamily"]    = QuoteFontFamily(session.ProfileFontFamily);
         if (session.ProfileFontSize      != null) opts["fontSize"]      = session.ProfileFontSize;
         if (session.ProfileFontWeight    != null) opts["fontWeight"]    = session.ProfileFontWeight;
         if (session.ProfileFontLigatures != null) opts["fontLigatures"] = session.ProfileFontLigatures;
@@ -295,6 +295,18 @@ public sealed class TerminalBridge : IDisposable
             try { _webView.CoreWebView2?.PostWebMessageAsString(json); }
             catch { }
         });
+    }
+
+    // Older state.json entries may store an unquoted face like "0xProto Nerd Font".
+    // CSS needs spaces-in-names quoted; quote + add a monospace fallback at apply
+    // time so existing saved sessions render correctly without a re-import.
+    private static string QuoteFontFamily(string face)
+    {
+        face = face.Trim();
+        if (face.Length == 0) return face;
+        if (face.StartsWith('\'') || face.StartsWith('"') || face.Contains(','))
+            return face;
+        return $"'{face}', monospace";
     }
 
     private static bool HasAnyOverride(ShellSession s) =>

--- a/tests/CodeShellManager.Tests/WindowsTerminalProfileServiceTests.cs
+++ b/tests/CodeShellManager.Tests/WindowsTerminalProfileServiceTests.cs
@@ -20,7 +20,7 @@ public class WindowsTerminalProfileServiceTests
 
         var ps = profiles.Single(p => p.Name == "PowerShell");
         Assert.Equal("pwsh.exe -NoLogo", ps.Commandline);
-        Assert.Equal("Cascadia Code", ps.FontFamily);
+        Assert.Equal("'Cascadia Code', monospace", ps.FontFamily);
         Assert.Equal(12, ps.FontSize);
         Assert.Equal("normal", ps.FontWeight);
         Assert.Equal("bar", ps.CursorShape);
@@ -51,13 +51,13 @@ public class WindowsTerminalProfileServiceTests
 
         var inherits = profiles.Single(p => p.Name == "Inherits");
         Assert.Equal("pwsh.exe", inherits.Commandline);
-        Assert.Equal("Cascadia Mono", inherits.FontFamily);
+        Assert.Equal("'Cascadia Mono', monospace", inherits.FontFamily);
         Assert.Equal(11, inherits.FontSize);
         Assert.Equal("4px", inherits.Padding);
 
         var overrides = profiles.Single(p => p.Name == "Overrides");
         Assert.Equal("cmd.exe", overrides.Commandline);
-        Assert.Equal("Cascadia Mono", overrides.FontFamily);
+        Assert.Equal("'Cascadia Mono', monospace", overrides.FontFamily);
         Assert.Equal("12px", overrides.Padding);
     }
 


### PR DESCRIPTION
### What changed
- **ConPTY stdio leak**: detach the WPF app from any inherited std handles / console at startup. When launched from a parent that gives us redirected handles (e.g. `dotnet run`, bash background tasks), ConPTY children were inheriting those handles and writing to the launching shell instead of the PTY pipe — leaving xterm with no output and broken input.
- **Profile font face quoting**: Windows Terminal stores font faces as bare names like `0xProto Nerd Font`. xterm.js drops the value straight into CSS `font-family`, where unquoted names with spaces fail to resolve. Quote the value (and append `, monospace`) both at import time and when applying overrides, so existing saved sessions render correctly without re-import.
- **Cell seams on block characters**: enable xterm's `customGlyphs` so box-drawing/block characters render with built-in glyphs that tile flush across cells.

### Testing
- [ ] Launch the app from `dotnet run` (or any console parent). Create a session — terminal should print and accept input.
- [ ] Open a session that uses a Windows Terminal profile with a multi-word font face. Confirm the configured font is rendering, not the default Cascadia.
- [ ] Run something that draws box characters (e.g. `tree`, `claude`'s welcome card). Confirm no thin seams between adjacent solid blocks.
- [ ] Existing sessions in `state.json` (with unquoted `ProfileFontFamily`) should pick up the correct font without manual re-import.

### Developer notes
- The stdio detach uses `FreeConsole` + `SetStdHandle(..., IntPtr.Zero)`. `FreeConsole` alone isn't enough — when the parent hands us pipe handles (not a console), only clearing the std handle slots prevents inheritance.
- `customGlyphs` only covers the box-drawing/block Unicode ranges. Nerd Font Private Use Area glyphs still seam in the DOM renderer; the proper fix for those is a canvas/webgl renderer addon, which would require pulling in a new asset. Not done here.
- Font face normalization is applied both at import (`WindowsTerminalProfileService.QuoteFontFace`) and at apply time (`TerminalBridge.QuoteFontFamily`) so saved sessions don't need to be re-imported to benefit.