### PR TITLE
fix: settings persistence, profile/command separation, focus on launch

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -462,6 +462,7 @@ public partial class MainWindow : Window
         _vm.RegisterSession(vm);
         RefreshTerminalLayout();
         bridge.FitTerminal();
+        bridge.FocusTerminal();
         UpdateAlertBadge();
         EmptyState.Visibility = Visibility.Collapsed;
     }

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -325,6 +325,10 @@ public sealed class TerminalBridge : IDisposable
         if (!_ready) return;
         WpfApplication.Current?.Dispatcher.BeginInvoke(() =>
         {
+            // Move WPF keyboard focus onto the WebView2 first — without this,
+            // posting "focus" to xterm has no effect because keystrokes never
+            // reach the webview at all (sidebar/toolbar swallows them).
+            try { _webView.Focus(); } catch { }
             try { _webView.CoreWebView2?.PostWebMessageAsString("{\"type\":\"focus\"}"); }
             catch { }
         });

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -161,20 +161,16 @@ public partial class NewSessionDialog : Window
         if (string.IsNullOrWhiteSpace(NameBox.Text))
             NameBox.Text = profile.Name;
 
-        // Add the profile's commandline as a transient entry in CommandCombo and select it
+        // Make the profile's commandline available as a Command option, but
+        // don't overwrite an explicit user selection — Profile contributes
+        // appearance overrides; Command is what actually runs.
         var cmdString = profile.Commandline;
-        var existing = CommandCombo.Items.OfType<ComboBoxItem>()
-            .FirstOrDefault(it => it.Tag?.ToString() == cmdString);
-        if (existing != null)
-        {
-            CommandCombo.SelectedItem = existing;
-        }
-        else
+        if (!string.IsNullOrWhiteSpace(cmdString)
+            && !CommandCombo.Items.OfType<ComboBoxItem>().Any(it => it.Tag?.ToString() == cmdString))
         {
             // Insert just before the [custom] item (which is always last)
-            var item = new ComboBoxItem { Content = cmdString, Tag = cmdString };
-            CommandCombo.Items.Insert(CommandCombo.Items.Count - 1, item);
-            CommandCombo.SelectedItem = item;
+            CommandCombo.Items.Insert(CommandCombo.Items.Count - 1,
+                new ComboBoxItem { Content = cmdString, Tag = cmdString });
         }
 
         // Stash overrides

--- a/src/CodeShellManager/Views/SettingsWindow.xaml.cs
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml.cs
@@ -43,6 +43,7 @@ public partial class SettingsWindow : Window
             TerminalLineHeight = current.TerminalLineHeight,
             IndexTerminalOutput = current.IndexTerminalOutput,
             OutputRetentionDays = current.OutputRetentionDays,
+            LaunchCommands = new System.Collections.Generic.List<string>(current.LaunchCommands),
         };
 
         // Populate controls
@@ -81,7 +82,10 @@ public partial class SettingsWindow : Window
         if (FontWeightCombo.SelectedIndex < 0)
             FontWeightCombo.SelectedIndex = 0;
 
-        // Select matching command in ComboBox
+        // Populate combo from the editable launch-command list so additions show up.
+        DefaultCommandCombo.Items.Clear();
+        foreach (var cmd in _edited.LaunchCommands)
+            DefaultCommandCombo.Items.Add(new ComboBoxItem { Content = cmd, Tag = cmd });
         foreach (ComboBoxItem item in DefaultCommandCombo.Items)
         {
             if (item.Tag?.ToString() == _edited.DefaultCommand)
@@ -90,7 +94,7 @@ public partial class SettingsWindow : Window
                 break;
             }
         }
-        if (DefaultCommandCombo.SelectedIndex < 0)
+        if (DefaultCommandCombo.SelectedIndex < 0 && DefaultCommandCombo.Items.Count > 0)
             DefaultCommandCombo.SelectedIndex = 0;
     }
 


### PR DESCRIPTION
### What changed
- **Custom launch commands persist correctly**: clone `LaunchCommands` into the Settings dialog's working copy. Previously the dialog edited a fresh `AppSettings` whose `LaunchCommands` was the hard-coded default — opening Settings showed defaults (which happened to look identical to the saved list), and saving overwrote the persisted list with whatever was in the textbox. Adding e.g. `nexus`, saving, and reopening Settings now shows it still there.
- **Default Command combo follows the list**: the combo is now populated from `LaunchCommands` instead of the hard-coded XAML items, so anything the user adds (like `nexus`) is selectable as the default.
- **Profile selection no longer hijacks Command**: in the New Session dialog, picking a Windows Terminal profile previously replaced your Command selection with the profile's `commandline` (e.g. `powershell.exe`). The profile now contributes only appearance overrides; the profile's commandline is still added to the Command list as a selectable option, but selection is preserved.
- **Focus on new sessions**: after launching a session, `FocusTerminal()` is called and `WebView2.Focus()` runs first so WPF actually routes keystrokes there. Without this, keys (including arrow keys for TUI menus) went to the sidebar/toolbar instead of the terminal.

### Testing
- [ ] Open Settings, add a new line `nexus`, save. Reopen Settings — `nexus` is still listed and appears in the **Default Command** dropdown.
- [ ] In New Session, set Command = `nexus`, then pick a profile (e.g. *Windows PowerShell*). Command stays as `nexus`. Hit Start — `nexus` actually runs.
- [ ] Launch any session — focus is on the new terminal pane, type immediately, arrow keys navigate the running TUI.

### Developer notes
- The settings clone constructor was missing a `LaunchCommands` copy; this is a list, so it's cloned as `new List<string>(current.LaunchCommands)` to avoid the dialog mutating live settings if the user cancels.
- The hard-coded `<ComboBoxItem>` entries in `SettingsWindow.xaml` for Default Command remain (Items.Clear() runs before population), but they're effectively dead — kept as a fallback for the brief window before code-behind runs. Cleanup is a separate concern.
- For focus: `_webView.Focus()` (WPF focus) is required first; otherwise `term.focus()` only moves DOM focus inside a webview that WPF isn't routing keys to. The xterm-side focus call is kept too because xterm tracks an internal "focused" state that affects cursor blink and bracketed paste.