### PR TITLE
feat: shell integration channel (OSC 9001) for color, git, title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.
 
 | Key | Effect |
 |---|---|
-| `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. |
+| `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. 8-digit values use alpha-last (`#rrggbbaa`); CSM converts to WPF's `#aarrggbb` internally. |
 | `git-branch` | Set `SessionViewModel.GitBranch` directly, bypassing `GitService`. |
 | `git-dirty` | `1`/`true` → dirty-marker shown; `0`/anything else → clean. |
 | `title` | Renames the session (calls `vm.Rename`). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,8 @@ When any override is set, `LaunchSessionAsync` calls `bridge.ApplyProfileOverrid
 
 Programs running inside a terminal can push session state up to CSM by emitting a custom OSC sequence — useful for SSH overlays (e.g. `nexus`) where CSM cannot inspect the remote repo locally.
 
+> **Integrator-facing reference:** [`docs/shell-integration.md`](docs/shell-integration.md) (wire format + bash/PowerShell/Python/Node/Rust/Go snippets). The notes below are CSM-internal.
+
 **Wire format:** `ESC ] 9001 ; key=value ; key=value … ST`
 
 ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,29 @@ When any override is set, `LaunchSessionAsync` calls `bridge.ApplyProfileOverrid
 
 **Once stamped, profile overrides are independent.** A session keeps its appearance even if the user later edits or deletes the source profile in Windows Terminal.
 
+## Shell Integration (OSC 9001)
+
+Programs running inside a terminal can push session state up to CSM by emitting a custom OSC sequence — useful for SSH overlays (e.g. `nexus`) where CSM cannot inspect the remote repo locally.
+
+**Wire format:** `ESC ] 9001 ; key=value ; key=value … ST`
+
+ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.
+
+**Recognised keys:**
+
+| Key | Effect |
+|---|---|
+| `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. |
+| `git-branch` | Set `SessionViewModel.GitBranch` directly, bypassing `GitService`. |
+| `git-dirty` | `1`/`true` → dirty-marker shown; `0`/anything else → clean. |
+| `title` | Renames the session (calls `vm.Rename`). |
+
+Unknown keys are ignored. Multiple keys can be sent in a single sequence.
+
+**Pipeline:** `terminal-init.js` registers an OSC handler via `term.parser.registerOscHandler(9001, …)` (requires `allowProposedApi: true`, already set). It posts `{type: "shellIntegration", fields: {…}}` to WPF. `TerminalBridge` parses it and raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and calls `vm.ApplyShellIntegration(fields)` on the dispatcher, then `SaveStateAsync` so changes persist.
+
+The OSC handler returns `true` so xterm consumes the sequence and it doesn't render.
+
 ## Sleep / Wake (Dormant Sessions)
 
 Sessions can be put to sleep instead of closed — the PTY is torn down but the `ShellSession` is kept in `state.json` (`IsDormant = true`) so it can be relaunched from the sidebar later. Useful when you have many long-running projects but only need a few live at once.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Built with WPF + [xterm.js](https://xtermjs.org/) + Windows ConPTY for full pseu
 - **Alert detection** — detects when Claude is waiting for input or tool approval; green/orange dot indicators
 - **Git status** — shows branch and dirty state in the sidebar per session
 - **Session rename** — double-click any session name or click ✏ to rename inline
+- **Shell integration** — programs running in a session can push their accent color, git branch / dirty state, and tab title to CSM via OSC 9001 (handy for SSH overlays). See [`docs/shell-integration.md`](docs/shell-integration.md).
 - **Auto-resume** — automatically resumes the last Claude Code session when restoring on startup (`--resume <id>`); toggleable in Settings
 - **SSH remote sessions** — connect to remote hosts using your existing SSH config; sessions persist across restarts
 - **Session history** — clicking a search result from a closed session offers to relaunch it

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -1,0 +1,161 @@
+# CodeShellManager Shell Integration
+
+Programs running inside a CodeShellManager terminal can push session state up to the host UI by emitting a custom OSC (Operating System Command) escape sequence. This is the recommended way for tools like SSH overlays, REPLs, and TUI apps to keep CSM's accent color, git status, and tab title in sync with whatever the program actually represents — even when CSM cannot inspect that state locally.
+
+## Wire format
+
+```
+ESC ] 9001 ; key=value ; key=value … ST
+```
+
+- `ESC` is `\x1b` (`0o33`, `27`).
+- `9001` is the CSM-namespaced OSC identifier.
+- `ST` ("string terminator") is either `BEL` (`\x07`) or `ESC \` (`\x1b\x5c`). Both are accepted.
+- Keys and values are separated by `=`. Multiple fields are separated by `;`.
+- Whitespace around keys/values is trimmed.
+- Unknown keys are silently ignored — safe to emit forward-compatibly.
+- The whole sequence is consumed by xterm and never rendered.
+
+## Recognised keys
+
+| Key          | Value format            | Effect |
+|--------------|-------------------------|--------|
+| `color`      | `#rgb`, `#rrggbb`, `#rrggbbaa` | Override the session accent. Repaints the sidebar stripe and the active-pane ring immediately. |
+| `git-branch` | string                  | Set the branch label shown in the sidebar. Bypasses CSM's local `git` polling — useful for SSH/remote sessions. |
+| `git-dirty`  | `0`/`1` (or `false`/`true`) | Toggle the dirty marker (`*`) shown next to the branch. |
+| `title`      | string                  | Rename the session (same as double-clicking the sidebar entry). Persisted to `state.json`. |
+
+Multiple keys can be sent in a single sequence; CSM applies them atomically and saves state once.
+
+## Examples
+
+All examples below emit `color=#a6e3a1`, `git-branch=feat/foo`, `git-dirty=1`, `title=my-repo` in a single sequence. Adapt to your needs.
+
+### bash / zsh / sh
+
+```bash
+printf '\e]9001;color=#a6e3a1;git-branch=feat/foo;git-dirty=1;title=my-repo\e\\'
+```
+
+To refresh on every prompt, drop this into your shell init:
+
+```bash
+__csm_update() {
+  local branch dirty
+  branch=$(git symbolic-ref --short HEAD 2>/dev/null) || branch=""
+  [ -n "$(git status --porcelain 2>/dev/null)" ] && dirty=1 || dirty=0
+  printf '\e]9001;git-branch=%s;git-dirty=%s\e\\' "$branch" "$dirty"
+}
+PROMPT_COMMAND='__csm_update'    # bash
+# precmd_functions+=(__csm_update)  # zsh
+```
+
+### PowerShell
+
+```powershell
+$esc = [char]27
+"$esc]9001;color=#a6e3a1;git-branch=feat/foo;git-dirty=1;title=my-repo$esc\" | Write-Host -NoNewline
+```
+
+In a `prompt` function:
+
+```powershell
+function prompt {
+    $esc = [char]27
+    $branch = (git symbolic-ref --short HEAD 2>$null)
+    $dirty  = if ((git status --porcelain 2>$null)) { 1 } else { 0 }
+    Write-Host -NoNewline "$esc]9001;git-branch=$branch;git-dirty=$dirty$esc\"
+    "PS $($executionContext.SessionState.Path.CurrentLocation)> "
+}
+```
+
+### Python
+
+```python
+import sys
+
+def csm_update(**fields):
+    payload = ";".join(f"{k}={v}" for k, v in fields.items())
+    sys.stdout.write(f"\x1b]9001;{payload}\x1b\\")
+    sys.stdout.flush()
+
+csm_update(color="#a6e3a1", **{"git-branch": "feat/foo", "git-dirty": "1"}, title="my-repo")
+```
+
+### Node.js
+
+```js
+function csmUpdate(fields) {
+  const payload = Object.entries(fields).map(([k, v]) => `${k}=${v}`).join(';');
+  process.stdout.write(`\x1b]9001;${payload}\x1b\\`);
+}
+
+csmUpdate({ color: '#a6e3a1', 'git-branch': 'feat/foo', 'git-dirty': '1', title: 'my-repo' });
+```
+
+### Rust
+
+```rust
+fn csm_update(fields: &[(&str, &str)]) {
+    let payload: String = fields.iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(";");
+    print!("\x1b]9001;{payload}\x1b\\");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+}
+
+csm_update(&[
+    ("color", "#a6e3a1"),
+    ("git-branch", "feat/foo"),
+    ("git-dirty", "1"),
+    ("title", "my-repo"),
+]);
+```
+
+### Go
+
+```go
+package main
+
+import (
+    "fmt"
+    "strings"
+)
+
+func csmUpdate(fields map[string]string) {
+    parts := make([]string, 0, len(fields))
+    for k, v := range fields {
+        parts = append(parts, k+"="+v)
+    }
+    fmt.Printf("\x1b]9001;%s\x1b\\", strings.Join(parts, ";"))
+}
+```
+
+## Patterns
+
+**Update on every prompt.** Cheap, predictable, and handles `cd` / branch switches automatically. Use the shell snippets above.
+
+**Update on relevant events only.** If a prompt-hook is too coarse — e.g. inside a long-running TUI like `nexus` — call your update function whenever your internal state changes (new repo selected, dirty state changes, branch checked out, etc.).
+
+**Reset on exit.** If your program owns the session's accent for its lifetime, restore the default before exiting:
+
+```bash
+# Clearing color sends the empty string, which CSM treats as "use the default hash"
+# (only true if you've also chosen to clear ColorOverride; currently CSM keeps the
+# last value. To restore the original hash, leave the color key out entirely.)
+```
+
+In the current build, an emitted `color=` is sticky and persists in `state.json` across restarts. If you want it to revert when your program exits, emit nothing extra — but if a different program later runs in the same session, it will inherit your color until it sets its own.
+
+## Limitations
+
+- The protocol is one-way: CSM does not respond to OSC 9001 sequences with any data.
+- There's no acknowledgement that a sequence was parsed. Validate your output with the inspector if you want to be sure (DevTools is enabled in WebView2; press `F12` inside a terminal pane).
+- Color values must be valid CSS hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Named colors and `rgb()` syntax are rejected.
+- The terminating byte should be `BEL` or `ESC \`. xterm.js will eventually time out an unterminated OSC, but until then your text appears swallowed.
+
+## Pipeline (for CSM contributors)
+
+`terminal-init.js` registers the OSC handler via `term.parser.registerOscHandler(9001, …)`. The handler parses the payload, posts `{type: "shellIntegration", fields: {…}}` over the WebView2 message channel, and returns `true` so xterm consumes the sequence. `TerminalBridge.OnWebMessageReceived` raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and dispatches to `SessionViewModel.ApplyShellIntegration(fields)`, then triggers `SaveStateAsync`. Color/title changes propagate through `INotifyPropertyChanged` to repaint the sidebar stripe and active ring; git fields update `GitBranch` / `GitIsDirty`.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -20,7 +20,7 @@ ESC ] 9001 ; key=value ; key=value … ST
 
 | Key          | Value format            | Effect |
 |--------------|-------------------------|--------|
-| `color`      | `#rgb`, `#rrggbb`, `#rrggbbaa` | Override the session accent. Repaints the sidebar stripe and the active-pane ring immediately. |
+| `color`      | `#rgb`, `#rrggbb`, `#rrggbbaa` | Override the session accent. Repaints the sidebar stripe and the active-pane ring immediately. 8-digit values use **alpha-last** (`#rrggbbaa`) — CSM converts them internally to WPF's `#aarrggbb` format. |
 | `git-branch` | string                  | Set the branch label shown in the sidebar. Bypasses CSM's local `git` polling — useful for SSH/remote sessions. |
 | `git-dirty`  | `0`/`1` (or `false`/`true`) | Toggle the dirty marker (`*`) shown next to the branch. |
 | `title`      | string                  | Rename the session (same as double-clicking the sidebar entry). Persisted to `state.json`. |

--- a/src/CodeShellManager/Assets/terminal-init.js
+++ b/src/CodeShellManager/Assets/terminal-init.js
@@ -32,6 +32,25 @@
   term.open(document.getElementById('terminal'));
   fitAddon.fit();
 
+  // ── Shell integration: OSC 9001;key=value;key=value;ST ─────────────────────
+  // A program inside the terminal can push session state up to CSM by emitting:
+  //   ESC ] 9001 ; color=#89b4fa ; git-branch=main ; git-dirty=1 ; title=foo  ST
+  // Recognised keys: color, git-branch, git-dirty (0/1), title.
+  // Returning true tells xterm we consumed the sequence so it isn't rendered.
+  term.parser.registerOscHandler(9001, data => {
+    try {
+      const fields = {};
+      for (const part of String(data).split(';')) {
+        const eq = part.indexOf('=');
+        if (eq > 0) fields[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+      }
+      window.chrome.webview.postMessage(JSON.stringify({
+        type: 'shellIntegration', fields
+      }));
+    } catch {}
+    return true;
+  });
+
   // ── Input → PTY ────────────────────────────────────────────────────────────
   function sendInput(data) {
     window.chrome.webview.postMessage(JSON.stringify({ type: 'input', data }));

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -346,6 +346,14 @@ public partial class MainWindow : Window
             bridge.RawOutputReceived += alertDetector.Feed;
         }
 
+        // Shell programs (e.g. nexus over SSH) push session state via OSC 9001;
+        // forward those payloads to the VM, then save so accent/title persist.
+        bridge.ShellIntegrationReceived += fields =>
+        {
+            Dispatcher.Invoke(() => vm.ApplyShellIntegration(fields));
+            _ = _vm.SaveStateAsync();
+        };
+
         string assetsDir = Path.Combine(AppContext.BaseDirectory, "Assets");
         bool wantTransparent = session.ProfileBackgroundOpacity is < 1.0;
         string htmlFile = wantTransparent ? "terminal-transparent.html" : "terminal.html";
@@ -767,6 +775,15 @@ public partial class MainWindow : Window
                     case nameof(SessionViewModel.GitIsDirty):
                     case nameof(SessionViewModel.GitInfoLoaded):
                         UpdateGitText(gitText, vm);
+                        break;
+
+                    case nameof(SessionViewModel.AccentColor):
+                        try
+                        {
+                            stripe.Background = new SolidColorBrush(
+                                (Color)ColorConverter.ConvertFromString(vm.AccentColor));
+                        }
+                        catch { }
                         break;
                 }
             });
@@ -1302,6 +1319,21 @@ public partial class MainWindow : Window
                         termStatusDot.Fill = new SolidColorBrush(Color.FromRgb(0x6c, 0x70, 0x86));
                         termStatusDot.ToolTip = "Running";
                     }
+                });
+            }
+            else if (args.PropertyName == nameof(SessionViewModel.AccentColor))
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    try
+                    {
+                        var c = (Color)ColorConverter.ConvertFromString(vm.AccentColor);
+                        wrapper.BorderBrush = new SolidColorBrush(c);
+                        activeRing.Tag = vm.AccentColor;
+                        // If this session is active, re-apply the ring brush immediately
+                        if (vm.IsActive) activeRing.BorderBrush = new SolidColorBrush(c);
+                    }
+                    catch { }
                 });
             }
         };

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -347,11 +347,11 @@ public partial class MainWindow : Window
         }
 
         // Shell programs (e.g. nexus over SSH) push session state via OSC 9001;
-        // forward those payloads to the VM, then save so accent/title persist.
+        // forward those payloads to the VM, then debounce-save so accent/title persist.
         bridge.ShellIntegrationReceived += fields =>
         {
             Dispatcher.Invoke(() => vm.ApplyShellIntegration(fields));
-            _ = _vm.SaveStateAsync();
+            _vm.SaveStateDebounced();
         };
 
         string assetsDir = Path.Combine(AppContext.BaseDirectory, "Assets");

--- a/src/CodeShellManager/Services/StateService.cs
+++ b/src/CodeShellManager/Services/StateService.cs
@@ -44,9 +44,11 @@ public class StateService : IDisposable
 
     public async Task SaveAsync(AppState state)
     {
-        await _writeLock.WaitAsync();
+        bool acquired = false;
         try
         {
+            await _writeLock.WaitAsync();
+            acquired = true;
             var path = StatePath;
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             string json = JsonSerializer.Serialize(state, Options);
@@ -55,7 +57,7 @@ public class StateService : IDisposable
         catch { /* non-critical: disk full, permissions, or serialization errors */ }
         finally
         {
-            _writeLock.Release();
+            if (acquired) _writeLock.Release();
         }
     }
 

--- a/src/CodeShellManager/Services/StateService.cs
+++ b/src/CodeShellManager/Services/StateService.cs
@@ -2,12 +2,13 @@ using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using CodeShellManager.Models;
 
 namespace CodeShellManager.Services;
 
-public class StateService
+public class StateService : IDisposable
 {
     private static string StatePath =>
         Environment.GetEnvironmentVariable("CSM_STATE_PATH")
@@ -20,6 +21,8 @@ public class StateService
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
+
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
 
     /// <summary>Returns the resolved state file path (respects CSM_STATE_PATH env var).</summary>
     public static string GetPath() => StatePath;
@@ -41,6 +44,7 @@ public class StateService
 
     public async Task SaveAsync(AppState state)
     {
+        await _writeLock.WaitAsync();
         try
         {
             var path = StatePath;
@@ -48,6 +52,15 @@ public class StateService
             string json = JsonSerializer.Serialize(state, Options);
             await File.WriteAllTextAsync(path, json);
         }
-        catch { /* non-critical */ }
+        catch { /* non-critical: disk full, permissions, or serialization errors */ }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _writeLock.Dispose();
     }
 }

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -31,6 +31,12 @@ public sealed class TerminalBridge : IDisposable
     public event Action? UserInput;
 
     /// <summary>
+    /// Fires when the running shell program emits OSC 9001 (CSM shell integration).
+    /// Carries the parsed key=value fields it included (color, git-branch, git-dirty, title, …).
+    /// </summary>
+    public event Action<System.Collections.Generic.IReadOnlyDictionary<string, string>>? ShellIntegrationReceived;
+
+    /// <summary>
     /// Fires when the user presses a keyboard accelerator (Ctrl-combo, F-key, etc.)
     /// while the WebView2 has focus. Subscribers set <c>e.Handled = true</c> to prevent
     /// the key from also reaching xterm.js. The WPF WebView2 wrapper forwards
@@ -228,6 +234,21 @@ public sealed class TerminalBridge : IDisposable
                     if (!string.IsNullOrEmpty(copy))
                         WpfApplication.Current?.Dispatcher.Invoke(() =>
                             WpfClipboard.SetText(copy));
+                    break;
+
+                case "shellIntegration":
+                    if (root.TryGetProperty("fields", out var fieldsEl)
+                        && fieldsEl.ValueKind == JsonValueKind.Object)
+                    {
+                        var dict = new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var prop in fieldsEl.EnumerateObject())
+                        {
+                            if (prop.Value.ValueKind == JsonValueKind.String)
+                                dict[prop.Name] = prop.Value.GetString() ?? "";
+                        }
+                        if (dict.Count > 0)
+                            ShellIntegrationReceived?.Invoke(dict);
+                    }
                     break;
 
                 case "filesDropped":

--- a/src/CodeShellManager/ViewModels/MainViewModel.cs
+++ b/src/CodeShellManager/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -12,11 +13,13 @@ namespace CodeShellManager.ViewModels;
 
 public enum LayoutMode { Single, TwoColumn, ThreeColumn, TwoByTwo, TwoRow, FourColumn, SixColumn, SixByTwo, SixByThree }
 
-public partial class MainViewModel : ObservableObject
+public partial class MainViewModel : ObservableObject, IDisposable
 {
     private readonly SessionManager _sessionManager;
     private readonly StateService _stateService;
     private AppState _appState = new();
+    private System.Threading.Timer? _saveDebounceTimer;
+    private readonly object _timerLock = new();
 
     public ObservableCollection<SessionViewModel> Sessions { get; } = [];
 
@@ -53,6 +56,28 @@ public partial class MainViewModel : ObservableObject
         _sessionManager.PopulateState(_appState);
         _appState.LastLayout = Layout.ToString();
         await _stateService.SaveAsync(_appState);
+    }
+
+    /// <summary>
+    /// Debounced save for high-frequency events (e.g., OSC 9001 shell integration).
+    /// Coalesces multiple rapid calls into a single write after 500ms of idle.
+    /// Thread-safe: uses lock to prevent race conditions on timer replacement.
+    /// </summary>
+    public void SaveStateDebounced()
+    {
+        lock (_timerLock)
+        {
+            _saveDebounceTimer?.Dispose();
+            _saveDebounceTimer = new System.Threading.Timer(
+                _ => App.Current.Dispatcher.InvokeAsync(async () =>
+                {
+                    try { await SaveStateAsync(); }
+                    catch { /* non-critical: state persistence failures (disk full, permissions) */ }
+                }),
+                null,
+                500,
+                Timeout.Infinite);
+        }
     }
 
     public AppSettings Settings => _appState.Settings;
@@ -179,5 +204,14 @@ public partial class MainViewModel : ObservableObject
         newIndex = Math.Clamp(newIndex, 0, Sessions.Count - 1);
         if (cur != newIndex) Sessions.Move(cur, newIndex);
         _ = SaveStateAsync();
+    }
+
+    public void Dispose()
+    {
+        lock (_timerLock)
+        {
+            _saveDebounceTimer?.Dispose();
+            _saveDebounceTimer = null;
+        }
     }
 }

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -110,7 +110,7 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Applies a CSM shell-integration payload (OSC 9001) emitted by the running program.
-    /// Recognised keys: <c>color</c> (#rrggbb), <c>git-branch</c>, <c>git-dirty</c> (0/1),
+    /// Recognised keys: <c>color</c> (#rrggbb / #aarrggbb), <c>git-branch</c>, <c>git-dirty</c> (0/1),
     /// <c>title</c>. Unknown keys are ignored. Useful for SSH overlays whose remote
     /// state CSM cannot inspect locally.
     /// </summary>
@@ -118,7 +118,9 @@ public partial class SessionViewModel : ObservableObject, IDisposable
     {
         if (fields.TryGetValue("color", out var color) && IsValidHexColor(color))
         {
-            Session.ColorOverride = color;
+            // WPF ColorConverter.ConvertFromString interprets 8-digit hex as #AARRGGBB.
+            // Integrators emit #rrggbbaa (alpha last), so we reorder before storing.
+            Session.ColorOverride = ToWpfHexColor(color);
             OnPropertyChanged(nameof(AccentColor));
         }
 
@@ -146,6 +148,23 @@ public partial class SessionViewModel : ObservableObject, IDisposable
         for (int i = 1; i < s.Length; i++)
             if (!Uri.IsHexDigit(s[i])) return false;
         return true;
+    }
+
+    /// <summary>
+    /// Converts an integrator-supplied hex color to WPF format.
+    /// <para>
+    /// 6-digit (<c>#rrggbb</c>) and 3-digit (<c>#rgb</c>) values are stored as-is.
+    /// 8-digit values use the integrator convention <c>#rrggbbaa</c> (alpha last),
+    /// but WPF's <see cref="System.Windows.Media.ColorConverter"/> expects <c>#AARRGGBB</c>
+    /// (alpha first), so we reorder to <c>#aarrggbb</c>.
+    /// </para>
+    /// </summary>
+    private static string ToWpfHexColor(string s)
+    {
+        // Only 8-digit (#rrggbbaa) needs reordering; 3- and 6-digit are fine as-is.
+        if (s.Length == 9)
+            return "#" + s[7..9] + s[1..7];
+        return s;
     }
 
     public void RaiseAlert(string message, AlertType alertType = AlertType.InputRequired)

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -99,6 +99,42 @@ public partial class SessionViewModel : ObservableObject, IDisposable
             System.Diagnostics.Process.Start("explorer.exe", Session.WorkingFolder);
     }
 
+    /// <summary>
+    /// Applies a CSM shell-integration payload (OSC 9001) emitted by the running program.
+    /// Recognised keys: <c>color</c> (#rrggbb), <c>git-branch</c>, <c>git-dirty</c> (0/1),
+    /// <c>title</c>. Unknown keys are ignored. Useful for SSH overlays whose remote
+    /// state CSM cannot inspect locally.
+    /// </summary>
+    public void ApplyShellIntegration(System.Collections.Generic.IReadOnlyDictionary<string, string> fields)
+    {
+        if (fields.TryGetValue("color", out var color) && IsValidHexColor(color))
+        {
+            Session.ColorOverride = color;
+            OnPropertyChanged(nameof(AccentColor));
+        }
+
+        if (fields.TryGetValue("git-branch", out var branch))
+        {
+            GitBranch = string.IsNullOrWhiteSpace(branch) ? null : branch;
+            GitInfoLoaded = true;
+        }
+
+        if (fields.TryGetValue("git-dirty", out var dirty))
+            GitIsDirty = dirty == "1" || string.Equals(dirty, "true", StringComparison.OrdinalIgnoreCase);
+
+        if (fields.TryGetValue("title", out var title) && !string.IsNullOrWhiteSpace(title))
+            Rename(title.Trim());
+    }
+
+    private static bool IsValidHexColor(string s)
+    {
+        if (string.IsNullOrEmpty(s) || s[0] != '#') return false;
+        if (s.Length != 4 && s.Length != 7 && s.Length != 9) return false;
+        for (int i = 1; i < s.Length; i++)
+            if (!Uri.IsHexDigit(s[i])) return false;
+        return true;
+    }
+
     public void RaiseAlert(string message, AlertType alertType = AlertType.InputRequired)
     {
         NeedsAttention = true;

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -62,6 +62,15 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     private readonly CancellationTokenSource _gitPollCts = new();
 
+    // Set by ApplyShellIntegration when the running program pushes git-branch
+    // or git-dirty via OSC 9001. Tells the local poller to stand down: the
+    // program is sourcing its own git state (e.g. `nexus ssh` into a container
+    // whose /workspace branch is unrelated to the host CWD) and the local
+    // poll would otherwise clobber the OSC value every 10s. Sticky for the
+    // lifetime of the session — once a program declares itself the source of
+    // truth, we trust it.
+    private bool _gitOverriddenByOsc;
+
     public SessionViewModel(ShellSession session)
     {
         Session = session;
@@ -71,7 +80,7 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     public async Task RefreshGitInfoAsync()
     {
-        if (Session.IsRemote) return;
+        if (Session.IsRemote || _gitOverriddenByOsc) return;
         var (branch, isDirty) = await GitService.GetGitInfoAsync(Session.WorkingFolder);
         GitBranch = branch;
         GitIsDirty = isDirty;
@@ -117,10 +126,14 @@ public partial class SessionViewModel : ObservableObject, IDisposable
         {
             GitBranch = string.IsNullOrWhiteSpace(branch) ? null : branch;
             GitInfoLoaded = true;
+            _gitOverriddenByOsc = true;
         }
 
         if (fields.TryGetValue("git-dirty", out var dirty))
+        {
             GitIsDirty = dirty == "1" || string.Equals(dirty, "true", StringComparison.OrdinalIgnoreCase);
+            _gitOverriddenByOsc = true;
+        }
 
         if (fields.TryGetValue("title", out var title) && !string.IsNullOrWhiteSpace(title))
             Rename(title.Trim());


### PR DESCRIPTION
### What changed
- **New shell-integration channel** via OSC 9001. Programs running inside a CSM terminal can push session state up to the host UI:
  - `color=#hex` — overrides the session accent. Repaints the sidebar stripe and the active-pane ring immediately, persists to `state.json`.
  - `git-branch=…`, `git-dirty=0|1` — updates the sidebar git label, bypassing CSM's local `git status` polling. Especially useful for SSH overlays whose remote repo state CSM can't inspect.
  - `title=…` — renames the session (same as double-clicking the sidebar entry), persisted.
- **Mid-flight changes are live.** Every emission triggers a full repaint. Multiple keys in one sequence are applied atomically.
- **Local git poller stands down once OSC takes over.** Once a session has pushed git info via OSC, the 10s local poller stops touching `GitBranch`/`GitIsDirty` for the lifetime of the session — otherwise the local CWD's git state would clobber the OSC value every poll.
- **Public integrator docs** at `docs/shell-integration.md`: wire format, key reference, copy-pasteable snippets for bash/zsh, PowerShell, Python, Node, Rust, Go. Cross-linked from README and CLAUDE.md.

### Testing
- [ ] Open a session, then run `printf '\e]9001;color=#a6e3a1\e\'`. Sidebar stripe + active ring go green.
- [ ] Run `printf '\e]9001;git-branch=feat/foo;git-dirty=1\e\'`. Sidebar shows `⎇ feat/foo*`. `cd`-ing the local shell to a different repo no longer updates the label (poller is suppressed).
- [ ] Run `printf '\e]9001;title=Demo\e\'`. Tab title becomes `Demo`; persists across app restart.
- [ ] Restart CSM. Color and title stay; git label reverts to local poll (poller suppression is per-session, not persisted).
- [ ] Multi-field in one sequence: `printf '\e]9001;color=#cba6f7;git-branch=main;git-dirty=0;title=ok\e\'` — all four apply at once.

### Developer notes
- **OSC 9001 was picked as the namespace** to avoid collisions with iTerm2's 1337, VS Code's 633, and the shell-integration 133 range. xterm.js's `parser.registerOscHandler` requires `allowProposedApi: true` (already enabled).
- **The handler returns `true`** so xterm consumes the bytes — the sequence never renders. This is the documented signal in xterm.js for "I handled it".
- **`SaveStateAsync` runs after every OSC application.** If shells get chatty (e.g. animating colors at high rate), this should be debounced — currently not throttled.
- **`_gitOverriddenByOsc` is sticky for the session's lifetime, not persisted.** Idea: once a program declares itself the source of truth, trust it. On next launch the local poller starts fresh until the program re-declares.
- **Color values are validated** (`#rgb`/`#rrggbb`/`#rrggbbaa` only). CSS named colors and `rgb()` are rejected silently — `IsValidHexColor` won't set them, and the rest of the payload still applies.