### PR TITLE
Stagger consecutive claude restores to avoid ~/.claude.json corruption

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -163,9 +163,16 @@ public partial class MainWindow : Window
             // Launch live sessions first, then append dormant entries — keeps the
             // "dormant always at the bottom" invariant that SleepSession and
             // RebuildSidebarOrder enforce at runtime.
+            // Stagger consecutive claude launches: claude's CLI does an unlocked
+            // read-modify-write on ~/.claude.json at startup, so simultaneous
+            // boots can corrupt the user's profile.
+            bool lastWasClaude = false;
             foreach (var s in saved)
             {
                 if (s.IsDormant) continue;
+                bool isClaude = ClaudeSessionService.IsClaudeCommand(s.Command);
+                if (isClaude && lastWasClaude)
+                    await Task.Delay(2000);
                 try { await LaunchSessionAsync(s, restoring: true); }
                 catch (Exception ex)
                 {
@@ -173,6 +180,7 @@ public partial class MainWindow : Window
                     MessageBox.Show($"Failed to restore '{s.Name}': {ex.Message}",
                         "Restore Error", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
+                lastWasClaude = isClaude;
             }
             foreach (var s in saved)
             {


### PR DESCRIPTION
## Summary
- Claude's CLI does an unlocked read-modify-write on `~/.claude.json` at startup, so when CSM auto-restores several claude sessions back-to-back the writes race and can corrupt the user's profile.
- Added a 2s `Task.Delay` between any two **consecutive** claude restores in `MainWindow.OnLoaded`. Non-claude sessions and the first claude in the loop launch with no added delay, so startup cost only grows when there are multiple claude sessions to restore.

## Notes
- This is a workaround on the CSM side — the underlying race is in Claude itself and should be fixed upstream with proper file locking.
- 2s was chosen as a safe quiet period for claude's startup writes; if it proves too short we can raise it or move to a global mutex held by CSM around each claude launch.

## Test plan
- [ ] Launch CSM with several restored claude sessions and confirm `~/.claude.json` stays valid after every restart.
- [ ] Confirm non-claude sessions still restore without added delay.
- [ ] Confirm a single claude session restores with no added delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)