### PR TITLE
Ship terminal-init.js + transparent HTML in MSI; guard Assets drift in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,27 @@ jobs:
         with:
           dotnet-version: '10.x'
 
+      # ── Guard: WiX must reference every file in src/CodeShellManager/Assets.
+      # Portable ZIP ships the whole publish output, so this only bites MSI users
+      # (e.g. v0.4.1 silently dropped terminal-init.js → blank terminals).
+      - name: Verify WiX manifest covers all Assets files
+        shell: pwsh
+        run: |
+          $assetFiles = (Get-ChildItem 'src/CodeShellManager/Assets' -File).Name | Sort-Object
+          $wxs = Get-Content 'installer/CodeShellManager.wxs' -Raw
+          $matches = [regex]::Matches($wxs, '\$\(var\.PublishDir\)\\Assets\\([^"]+)')
+          $wxsRefs = ($matches | ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+          $diff = Compare-Object $assetFiles $wxsRefs
+          if ($diff) {
+            Write-Host "::error::installer/CodeShellManager.wxs is out of sync with src/CodeShellManager/Assets/"
+            $diff | ForEach-Object {
+              $side = if ($_.SideIndicator -eq '<=') { 'missing from WiX' } else { 'not present in Assets/' }
+              Write-Host "  $($_.InputObject) — $side"
+            }
+            exit 1
+          }
+          Write-Host "WiX/Assets in sync ($($assetFiles.Count) files)"
+
       # ── Build (every push / PR) ──────────────────────────────────────────────
       - name: Restore & Build
         run: dotnet build src/CodeShellManager/CodeShellManager.csproj -c Release

--- a/installer/CodeShellManager.wxs
+++ b/installer/CodeShellManager.wxs
@@ -54,9 +54,17 @@
         <File Source="$(var.PublishDir)\Assets\app.ico" KeyPath="yes" />
       </Component>
 
-      <!-- Assets — one component per file so auto-GUID works -->
+      <!-- Assets — one component per file so auto-GUID works.
+           If you add a new file to src/CodeShellManager/Assets, also add it here
+           or it will be missing from MSI installs (portable ZIP ships everything). -->
       <Component Directory="AssetsFolder" Guid="*">
         <File Source="$(var.PublishDir)\Assets\terminal.html" KeyPath="yes" />
+      </Component>
+      <Component Directory="AssetsFolder" Guid="*">
+        <File Source="$(var.PublishDir)\Assets\terminal-transparent.html" KeyPath="yes" />
+      </Component>
+      <Component Directory="AssetsFolder" Guid="*">
+        <File Source="$(var.PublishDir)\Assets\terminal-init.js" KeyPath="yes" />
       </Component>
       <Component Directory="AssetsFolder" Guid="*">
         <File Source="$(var.PublishDir)\Assets\xterm.js" KeyPath="yes" />


### PR DESCRIPTION
## Summary
- The v0.4.1 MSI shipped a broken WebView host: `terminal.html` `<script src=\"terminal-init.js\">` since 75280b1, plus transparent sessions load `terminal-transparent.html`, but neither file was in the WiX manifest. Installed users got a blank terminal pane; portable ZIP users were unaffected.
- Added both files to `installer/CodeShellManager.wxs`.
- Added a CI step that diffs the contents of `src/CodeShellManager/Assets/` against the `<File Source=\"\$(var.PublishDir)\Assets\...\">` refs in the WiX manifest and fails the build if they drift.

## Test plan
- [ ] CI passes on this PR (proves the new guard step works against the now-correct WiX).
- [ ] After merge + v0.4.2 tag: install the MSI on a clean Windows box, confirm terminals render and accept input.
- [ ] As a negative test, drop a junk file into Assets/ on a throwaway branch and confirm the new CI step fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)