### PR TITLE
feat: terminal trace setting + shutdown/restore stability fixes

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -88,10 +88,13 @@ public partial class MainWindow : Window
     private readonly System.Windows.Threading.DispatcherTimer _windowStateTimer;
     private bool _windowStateReady = false; // don't save before state is loaded
 
-    // OnClosing is async void, which WPF does not await — without this gate the window
+    // OnClosing is async void, which WPF does not await — without these gates the window
     // tears down while SaveStateAsync / claude disposal is still mid-flight. First entry
-    // cancels the close, runs the async cleanup, sets the flag, then re-invokes Close();
-    // the second entry passes through to base.OnClosing.
+    // sets _isShuttingDown, cancels the close, runs the async cleanup, sets _shutdownComplete,
+    // then re-invokes Close(); the second entry passes through to base.OnClosing. Any
+    // intermediate re-entries (e.g. user double-clicks the X) hit the _isShuttingDown gate
+    // and just cancel without re-running cleanup.
+    private bool _isShuttingDown = false;
     private bool _shutdownComplete = false;
 
     public MainWindow()
@@ -4295,16 +4298,20 @@ public partial class MainWindow : Window
 
     protected override async void OnClosing(System.ComponentModel.CancelEventArgs e)
     {
-        // Second entry: cleanup is finished, let WPF tear the window down for real.
+        // Final entry: cleanup is finished, let WPF tear the window down for real.
         if (_shutdownComplete)
         {
             base.OnClosing(e);
             return;
         }
 
-        // First entry: WPF won't wait for async work, so cancel this close, do the
-        // cleanup, then call Close() again to re-enter here through the branch above.
+        // WPF won't wait for async work, so cancel this close. The reclose at the bottom
+        // re-enters through the _shutdownComplete branch above.
         e.Cancel = true;
+
+        // Re-entry during async cleanup (e.g. user double-clicks the X) — just suppress.
+        if (_isShuttingDown) return;
+        _isShuttingDown = true;
 
         _windowStateTimer.Stop();
         if (_windowStateReady)

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -231,6 +231,10 @@ public partial class MainWindow : Window
             // read-modify-write on ~/.claude.json at startup, so simultaneous
             // boots can corrupt the user's profile.
             bool lastWasClaude = false;
+            // WebView2 user-data folder access-denied is a common shared-failure
+            // when another instance is running. Batch these so the user gets one
+            // actionable dialog at the end instead of N "Restore Error" popups.
+            var webView2AccessDenied = new List<string>();
             foreach (var s in saved)
             {
                 if (s.IsDormant) continue;
@@ -241,14 +245,28 @@ public partial class MainWindow : Window
                 catch (Exception ex)
                 {
                     Log($"Restore FAILED for '{s.Name}': {ex}");
-                    MessageBox.Show($"Failed to restore '{s.Name}': {ex.Message}",
-                        "Restore Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    if (IsWebView2AccessDenied(ex))
+                        webView2AccessDenied.Add(s.Name);
+                    else
+                        MessageBox.Show($"Failed to restore '{s.Name}': {ex.Message}",
+                            "Restore Error", MessageBoxButton.OK, MessageBoxImage.Warning);
                 }
                 lastWasClaude = isClaude;
             }
             foreach (var s in saved)
             {
                 if (s.IsDormant) AddDormantSidebarItem(s);
+            }
+            if (webView2AccessDenied.Count > 0)
+            {
+                MessageBox.Show(
+                    $"Could not initialize WebView2 for {webView2AccessDenied.Count} session(s):\n\n" +
+                    string.Join("\n", webView2AccessDenied.Select(n => "  • " + n)) +
+                    "\n\nThis usually means another CodeShellManager instance is running, " +
+                    "or a previous instance didn't shut down cleanly. Close any other " +
+                    "instances (or wait a few seconds for the WebView2 user-data folder " +
+                    "to unlock) and reopen the affected sessions from the sidebar.",
+                    "WebView2 unavailable", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
         }
         else
@@ -258,6 +276,14 @@ public partial class MainWindow : Window
             await _vm.SaveStateAsync();
         }
     }
+
+    // Detects WebView2 user-data folder access-denied, which surfaces as
+    // UnauthorizedAccessException from CoreWebView2Environment.CreateAsync /
+    // CreateCoreWebView2ControllerAsync when another process is holding the
+    // folder. We surface a clearer message in that specific case.
+    private static bool IsWebView2AccessDenied(Exception ex) =>
+        ex is UnauthorizedAccessException
+        && (ex.StackTrace?.Contains("WebView2", StringComparison.Ordinal) ?? false);
 
     private void RestoreWindowState()
     {
@@ -827,6 +853,11 @@ public partial class MainWindow : Window
         var bridge = new TerminalBridge(webView);
         vm.Bridge = bridge;
         bridge.AcceleratorKeyPressed += OnBridgeAcceleratorKey;
+        // Diagnostics — bridge logs per-keystroke / per-output-chunk timing when
+        // AppSettings.DebugTerminalTrace is on. Shares the live settings ref so
+        // toggling in the Settings dialog takes effect on existing sessions.
+        bridge.DebugSettings = _vm.Settings;
+        bridge.DebugSessionId = session.Id.Length >= 8 ? session.Id[..8] : session.Id;
 
         // Wire output indexer and alert detector
         if (_db != null)
@@ -3863,6 +3894,7 @@ public partial class MainWindow : Window
             _vm.Settings.TerminalFontWeight = edited.TerminalFontWeight;
             _vm.Settings.TerminalLetterSpacing = edited.TerminalLetterSpacing;
             _vm.Settings.TerminalLineHeight = edited.TerminalLineHeight;
+            _vm.Settings.DebugTerminalTrace = edited.DebugTerminalTrace;
             _ = _vm.SaveStateAsync();
 
             // Push font settings to all active terminal sessions
@@ -4068,8 +4100,13 @@ public partial class MainWindow : Window
         await _vm.SaveStateAsync();
         foreach (var vm in _vm.Sessions.ToList())
             vm.Dispose();
-        _db?.Close();
-        _db?.Dispose();
+        // OutputIndexer.Dispose now drains its worker first, but SqliteConnection.Close
+        // has been observed to throw NRE internally on shutdown — swallow + log so it
+        // doesn't escape as an unhandled exception during application exit.
+        try { _db?.Close(); }
+        catch (Exception ex) { Log($"OnClosing _db.Close threw: {ex}"); }
+        try { _db?.Dispose(); }
+        catch (Exception ex) { Log($"OnClosing _db.Dispose threw: {ex}"); }
         App.TrayIcon?.Dispose();
         base.OnClosing(e);
     }

--- a/src/CodeShellManager/Models/AppState.cs
+++ b/src/CodeShellManager/Models/AppState.cs
@@ -80,6 +80,13 @@ public class AppSettings
     public bool IndexTerminalOutput { get; set; } = true;
     public int OutputRetentionDays { get; set; } = 30;  // 0 = keep forever
 
+    /// <summary>
+    /// When on, TerminalBridge emits per-keystroke / per-output-chunk timing to
+    /// crash.log (prefix [DEBUG-tt]) so intermittent freezes can be diagnosed
+    /// after the fact. Off by default — has zero cost when off.
+    /// </summary>
+    public bool DebugTerminalTrace { get; set; } = false;
+
     // Terminal font settings
     public string TerminalFontFamily { get; set; } = "'Cascadia Code', 'Cascadia Mono', Consolas, 'Courier New', monospace";
     public int TerminalFontSize { get; set; } = 14;

--- a/src/CodeShellManager/Terminal/OutputIndexer.cs
+++ b/src/CodeShellManager/Terminal/OutputIndexer.cs
@@ -74,6 +74,11 @@ public partial class OutputIndexer : IDisposable
         if (_disposed) return;
         _disposed = true;
         _queue.Writer.Complete();
+        // Drain the worker before returning so any in-flight INSERTs finish before
+        // the shared SqliteConnection is closed. Bounded wait so a slow/stuck
+        // worker doesn't hang shutdown — pending writes are non-critical on exit.
+        try { _worker.Wait(TimeSpan.FromSeconds(2)); }
+        catch { /* AggregateException from worker exceptions — already swallowed inside */ }
     }
 
     [GeneratedRegex(@"\x1B\[[0-9;]*[mGKHFJABCDsuhl]|\x1B\].*?\x07|\x1B[=>]|\r", RegexOptions.Compiled)]

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -27,6 +27,13 @@ public sealed class TerminalBridge : IDisposable
     // Output that arrived before the page finished loading is buffered here
     private readonly System.Text.StringBuilder _outputBuffer = new();
 
+    // Diagnostics — gated by AppSettings.DebugTerminalTrace. Zero cost when off.
+    /// <summary>AppSettings reference whose DebugTerminalTrace flag gates [DEBUG-tt] logging.</summary>
+    public AppSettings? DebugSettings { get; set; }
+    /// <summary>Short session-id prefix included in [DEBUG-tt] lines so multi-session logs are readable.</summary>
+    public string? DebugSessionId { get; set; }
+    private long _lastOutputTickMs;
+
     public event Action<string>? RawOutputReceived;
     public event Action? UserInput;
 
@@ -47,6 +54,21 @@ public sealed class TerminalBridge : IDisposable
                 "CodeShellManager", "crash.log");
             System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
             System.IO.File.AppendAllText(path, $"[{DateTime.Now:HH:mm:ss.fff}] BRIDGE {msg}\n");
+        }
+        catch { }
+    }
+
+    private void Trace(string msg)
+    {
+        if (DebugSettings?.DebugTerminalTrace != true) return;
+        try
+        {
+            string path = System.IO.Path.Combine(
+                System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData),
+                "CodeShellManager", "crash.log");
+            System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+            System.IO.File.AppendAllText(path,
+                $"[{DateTime.Now:HH:mm:ss.fff}] [DEBUG-tt] {DebugSessionId ?? "?"} {msg}\n");
         }
         catch { }
     }
@@ -157,6 +179,14 @@ public sealed class TerminalBridge : IDisposable
 
     private void OnPtyData(string rawData)
     {
+        if (DebugSettings?.DebugTerminalTrace == true)
+        {
+            long now = Environment.TickCount64;
+            long gap = _lastOutputTickMs == 0 ? 0 : now - _lastOutputTickMs;
+            _lastOutputTickMs = now;
+            Trace($"OUTPUT recv len={rawData.Length} gap-since-prev={gap}ms");
+        }
+
         RawOutputReceived?.Invoke(rawData);
 
         if (!_ready)
@@ -167,8 +197,12 @@ public sealed class TerminalBridge : IDisposable
         }
 
         string json = JsonSerializer.Serialize(new { type = "output", data = rawData });
+        long enqueueAt = DebugSettings?.DebugTerminalTrace == true ? Environment.TickCount64 : 0;
+        int len = rawData.Length;
         WpfApplication.Current?.Dispatcher.BeginInvoke(() =>
         {
+            if (enqueueAt != 0)
+                Trace($"OUTPUT post dispatcher-latency={Environment.TickCount64 - enqueueAt}ms len={len}");
             try { _webView.CoreWebView2?.PostWebMessageAsString(json); }
             catch { }
         });
@@ -193,9 +227,22 @@ public sealed class TerminalBridge : IDisposable
             switch (type)
             {
                 case "input":
-                    _pty?.Write(root.GetProperty("data").GetString() ?? "");
+                {
+                    string data = root.GetProperty("data").GetString() ?? "";
+                    if (DebugSettings?.DebugTerminalTrace == true)
+                    {
+                        long t0 = Environment.TickCount64;
+                        Trace($"INPUT len={data.Length}");
+                        _pty?.Write(data);
+                        Trace($"PTY-WROTE elapsed={Environment.TickCount64 - t0}ms");
+                    }
+                    else
+                    {
+                        _pty?.Write(data);
+                    }
                     UserInput?.Invoke();
                     break;
+                }
 
                 case "resize":
                 {

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -201,10 +201,14 @@ public sealed class TerminalBridge : IDisposable
         int len = rawData.Length;
         WpfApplication.Current?.Dispatcher.BeginInvoke(() =>
         {
-            if (enqueueAt != 0)
-                Trace($"OUTPUT post dispatcher-latency={Environment.TickCount64 - enqueueAt}ms len={len}");
+            // Capture latency before any work so Trace's file I/O doesn't inflate the
+            // measurement, then post the WebView2 message before tracing so the trace
+            // overhead doesn't delay terminal rendering.
+            long latencyMs = enqueueAt != 0 ? Environment.TickCount64 - enqueueAt : 0;
             try { _webView.CoreWebView2?.PostWebMessageAsString(json); }
             catch { }
+            if (enqueueAt != 0)
+                Trace($"OUTPUT post dispatcher-latency={latencyMs}ms len={len}");
         });
     }
 

--- a/src/CodeShellManager/Views/SettingsWindow.xaml
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml
@@ -441,8 +441,8 @@
                 <Border BorderBrush="#313244" BorderThickness="0,0,0,1" Margin="0,4,0,0"/>
 
                 <StackPanel Margin="0,8,0,16">
-                    <CheckBox x:Name="DebugTerminalTraceCheck" Content="Trace terminal input/output to crash.log"/>
-                    <TextBlock Text="Logs every keystroke, PTY write, and output chunk with timing to %AppData%\CodeShellManager\crash.log (prefix [DEBUG-tt]). Use to diagnose terminal freezes. Off by default — turn on only when reproducing a problem."
+                    <CheckBox x:Name="DebugTerminalTraceCheck" Content="Trace terminal input/output timing to crash.log"/>
+                    <TextBlock Text="Logs timing and byte-length metadata only — never the keystrokes or output contents — for each PTY read/write and dispatcher post, to %AppData%\CodeShellManager\crash.log (prefix [DEBUG-tt]). Use to diagnose terminal freezes. Off by default — turn on only when reproducing a problem."
                                Foreground="#6c7086" FontSize="10" Margin="22,0,0,0" TextWrapping="Wrap"/>
                 </StackPanel>
 

--- a/src/CodeShellManager/Views/SettingsWindow.xaml
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml
@@ -423,6 +423,16 @@
                                Foreground="#6c7086" FontSize="10" Margin="0,4,0,0"/>
                 </StackPanel>
 
+                <!-- Diagnostics -->
+                <TextBlock Text="DIAGNOSTICS" Style="{StaticResource SectionHeader}"/>
+                <Border BorderBrush="#313244" BorderThickness="0,0,0,1" Margin="0,4,0,0"/>
+
+                <StackPanel Margin="0,8,0,16">
+                    <CheckBox x:Name="DebugTerminalTraceCheck" Content="Trace terminal input/output to crash.log"/>
+                    <TextBlock Text="Logs every keystroke, PTY write, and output chunk with timing to %AppData%\CodeShellManager\crash.log (prefix [DEBUG-tt]). Use to diagnose terminal freezes. Off by default — turn on only when reproducing a problem."
+                               Foreground="#6c7086" FontSize="10" Margin="22,0,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+
             </StackPanel>
         </ScrollViewer>
 

--- a/src/CodeShellManager/Views/SettingsWindow.xaml.cs
+++ b/src/CodeShellManager/Views/SettingsWindow.xaml.cs
@@ -48,6 +48,7 @@ public partial class SettingsWindow : Window
             TerminalLineHeight = current.TerminalLineHeight,
             IndexTerminalOutput = current.IndexTerminalOutput,
             OutputRetentionDays = current.OutputRetentionDays,
+            DebugTerminalTrace = current.DebugTerminalTrace,
             LaunchCommands = current.LaunchCommands.ToList(),
         };
 
@@ -86,6 +87,7 @@ public partial class SettingsWindow : Window
         MaxSearchResultsBox.Text = _edited.MaxSearchResults.ToString();
         IndexTerminalOutputCheck.IsChecked = _edited.IndexTerminalOutput;
         OutputRetentionDaysBox.Text = _edited.OutputRetentionDays.ToString();
+        DebugTerminalTraceCheck.IsChecked = _edited.DebugTerminalTrace;
         _ = UpdateDatabaseSizeLabelAsync();
         _ = LoadUsageStatsAsync();
         ApiKeyBox.Password = _edited.AnthropicApiKey;
@@ -165,6 +167,7 @@ public partial class SettingsWindow : Window
         _edited.IndexTerminalOutput = IndexTerminalOutputCheck.IsChecked == true;
         if (int.TryParse(OutputRetentionDaysBox.Text, out int retentionDays) && retentionDays >= 0)
             _edited.OutputRetentionDays = retentionDays;
+        _edited.DebugTerminalTrace = DebugTerminalTraceCheck.IsChecked == true;
 
         var commands = LaunchCommandsBox.Text
             .Split('\n', System.StringSplitOptions.RemoveEmptyEntries)


### PR DESCRIPTION
## Summary

- **`DebugTerminalTrace` setting** under Settings > Diagnostics (off by default). When on, `TerminalBridge` logs per-keystroke / per-output-chunk timing plus WPF dispatcher latency to `crash.log` under `[DEBUG-tt]` so intermittent terminal-input freezes can be diagnosed after the fact. Zero cost when off.
- **`OnClosing` SQLite NRE fix.** `OutputIndexer.Dispose` now drains its writer task (2s bounded wait) before `MainWindow` closes the shared `SqliteConnection`, so pending FTS5 INSERTs finish first. `_db.Close/Dispose` also wrapped in try/catch — defensive, since `SqliteConnection.Close` has been observed to NRE internally during shutdown regardless of the indexer race.
- **WebView2 restore UX.** Bulk restore now batches `UnauthorizedAccessException` from the WebView2 stack into one consolidated dialog at end of restore instead of N "Restore Error" popups, with a message pointing at the likely cause (another running instance locking the WebView2 user-data folder).

## Context

User reported an intermittent ~few-minute freeze when typing into a single terminal while others stayed responsive. Crash log audit didn't surface the freeze event itself (current logging is blind to it) but exposed the two latent shutdown/restore bugs above. The trace setting is the diagnostic loop for the original report — next occurrence will pin which stage (xterm.js, PTY, dispatcher) is stalling.

## Test plan

- [x] `dotnet build src/CodeShellManager/CodeShellManager.csproj` — 0 errors
- [x] `dotnet test tests/CodeShellManager.Tests/` — 82/82 pass
- [ ] Manual: toggle Settings > Diagnostics > "Trace terminal input/output" on, type, confirm `[DEBUG-tt]` lines in `%AppData%\CodeShellManager\crash.log`
- [ ] Manual: close the app cleanly — confirm no unhandled exception in crash.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)