### PR TITLE
fix(shutdown): defer reclose via Dispatcher so OnClosing yields first

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -4767,7 +4767,15 @@ public partial class MainWindow : Window
         App.TrayIcon?.Dispose();
 
         _shutdownComplete = true;
-        Close();
+        // Queue Close() on the dispatcher rather than calling it inline. If none of
+        // the awaits above actually yielded (e.g. --clean mode with no sessions —
+        // SaveStateAsync short-circuits, and the foreach loops over an empty list
+        // never await), control never returns to WPF between e.Cancel=true and this
+        // point, so WPF's internal _isClosing flag is still set and Close() throws
+        // "Cannot ... call Close ... while a Window is closing." Posting via
+        // BeginInvoke lets OnClosing return first, WPF resets _isClosing, then the
+        // queued Close() re-enters cleanly through the _shutdownComplete branch.
+        _ = Dispatcher.BeginInvoke(new System.Action(Close));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fixes `InvalidOperationException: Cannot ... call Close ... while a Window is closing.` thrown from `MainWindow.OnClosing` at line 4770 when shutting down in `--clean` debug mode.
- Queues the post-cleanup reclose via `Dispatcher.BeginInvoke` instead of calling `Close()` inline, so WPF gets a chance to process the cancelled first pass and reset its internal `_isClosing` flag.

## Root cause
`OnClosing` is `async void` using a cancel-then-reclose pattern: first entry sets `e.Cancel = true`, runs async cleanup, then calls `Close()` to re-enter through the `_shutdownComplete` branch. The cancellation only takes effect once `OnClosing` yields control back to WPF — that's when WPF reads `e.Cancel` and resets `_isClosing`.

In `--clean` mode none of the awaits actually yield:
- `SaveStateAsync()` short-circuits (`if (App.CleanStart) return;`), so its `await` resolves synchronously
- The `foreach` over `_vm.Sessions` is empty because clean mode clears the session list, so `await DisposeAndWaitForExitAsync` never runs
- The remaining DB close / tray dispose is synchronous

So `OnClosing` runs straight through to the final `Close()` without ever yielding — WPF's `_isClosing` is still `true` and `Close()` throws.

## Fix
Swap inline `Close()` for `_ = Dispatcher.BeginInvoke(new System.Action(Close))`. `OnClosing` returns first, WPF resets `_isClosing`, then the queued `Close()` re-enters cleanly through the `_shutdownComplete` branch. Works in both the no-yield clean case and the normal case with live sessions.

## Test plan
- [ ] Run `dotnet run --project src/CodeShellManager/CodeShellManager.csproj -- --clean` → close window → verify no exception in `crash.log` and the app exits cleanly.
- [ ] Run without `--clean` with several live sessions (including a Claude session) → close window → verify normal shutdown, `state.json` is written, and Claude sessions are disposed serially.
- [ ] Double-click the X during async cleanup → verify the second OnClosing entry still hits the `_isShuttingDown` gate and doesn't re-run cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)