### PR TITLE
chore(deps): align unit test framework with UITests

### DIFF
--- a/tests/CodeShellManager.Tests/CodeShellManager.Tests.csproj
+++ b/tests/CodeShellManager.Tests/CodeShellManager.Tests.csproj
@@ -6,9 +6,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Bumps `Microsoft.NET.Test.Sdk` 17.12.0 → 18.5.1 and `xunit.runner.visualstudio` 2.8.2 → 3.1.5 in `tests/CodeShellManager.Tests/`.
- Brings the unit test project in line with the UITests project after dependabot's #45 (which bumped UITests only).
- `xunit` stays at 2.9.3 — matches UITests.

## Test plan
- [x] `dotnet test tests/CodeShellManager.Tests/` — 82 passed, 0 failed (49ms, down from 367ms on the older runner)
- [ ] CI build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)