### PR TITLE
feat: first-class WSL session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Built with WPF + [xterm.js](https://xtermjs.org/) + Windows ConPTY for full pseu
 - **SSH remote sessions** — connect to remote hosts using your existing SSH config; sessions persist across restarts
 - **Windows Terminal profile import** — opt-in import of profiles from Windows Terminal's `settings.json`; pick a profile in the New Session dialog to stamp its font, color scheme, cursor and padding onto the new terminal
 - **Launch & shutdown spinners** — every starting session shows a brief overlay (`Starting <cmd>…` or `Connecting to <host>…`) until the first PTY byte arrives; closing the window shows a "Shutting down…" overlay during session disposal
+- **WSL sessions** — first-class session type for any installed WSL distro: distro picker (auto-detected via `wsl -l -v`), Linux working folder, optional `-u` user override; git status works via the `\\wsl$\<distro>` UNC view
 - **Session history** — clicking a search result from a closed session offers to relaunch it
 - **Configurable launch commands** — customise the commands available in the New Session dialog
 - **Claude badge** — sessions running `claude` commands get a visual indicator

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -582,6 +582,7 @@ public partial class MainWindow : Window
                 string.IsNullOrEmpty(primary.GroupId) ? null : primary.GroupId,
                 colorOverride: null,
                 afterSessionId: anchorId);
+            InheritSessionKindFrom(sibling, primary);
             // Inherit profile so siblings look identical.
             sibling.ProfileFontFamily = primary.ProfileFontFamily;
             sibling.ProfileFontSize = primary.ProfileFontSize;
@@ -616,20 +617,7 @@ public partial class MainWindow : Window
             string.IsNullOrEmpty(p.GroupId) ? null : p.GroupId,
             colorOverride: null,
             afterSessionId: parent.Id);
-        clone.Kind = p.Kind;
-        if (p.Kind == Models.SessionKind.Ssh)
-        {
-            clone.SshUser = p.SshUser;
-            clone.SshHost = p.SshHost;
-            clone.SshPort = p.SshPort;
-            clone.SshRemoteFolder = p.SshRemoteFolder;
-        }
-        else if (p.Kind == Models.SessionKind.Wsl)
-        {
-            clone.WslDistro = p.WslDistro;
-            clone.WslUser = p.WslUser;
-            clone.WslWorkingFolder = p.WslWorkingFolder;
-        }
+        InheritSessionKindFrom(clone, p);
         clone.ProfileFontFamily = p.ProfileFontFamily;
         clone.ProfileFontSize = p.ProfileFontSize;
         clone.ProfileFontWeight = p.ProfileFontWeight;
@@ -675,6 +663,55 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Propagates a parent session's <see cref="Models.SessionKind"/> and kind-specific
+    /// fields (SSH host/user/port, WSL distro/user) onto a freshly-created child
+    /// session. For WSL children it also derives <c>WslWorkingFolder</c> from the
+    /// child's <c>WorkingFolder</c>, which the worktree code paths set to a
+    /// <c>\\wsl$\&lt;distro&gt;\…</c> UNC. Without this step a new session spawned
+    /// from a WSL parent (Duplicate, sibling worktree, new worktree) silently falls
+    /// back to <see cref="Models.SessionKind.Local"/> and tries to run the parent's
+    /// command (e.g. <c>claude</c>) inside a Windows PowerShell at the UNC path.
+    /// </summary>
+    private static void InheritSessionKindFrom(Models.ShellSession target, Models.ShellSession source)
+    {
+        target.Kind = source.Kind;
+        if (source.Kind == Models.SessionKind.Ssh)
+        {
+            target.SshUser = source.SshUser;
+            target.SshHost = source.SshHost;
+            target.SshPort = source.SshPort;
+            target.SshRemoteFolder = source.SshRemoteFolder;
+            return;
+        }
+        if (source.Kind == Models.SessionKind.Wsl)
+        {
+            target.WslDistro = source.WslDistro;
+            target.WslUser = source.WslUser;
+
+            var (parsedDistro, parsedLinux) = Services.GitService.TryParseWslUnc(target.WorkingFolder);
+            if (!string.IsNullOrEmpty(parsedDistro))
+            {
+                // Common path: WorkingFolder is a WSL UNC the caller already built.
+                target.WslWorkingFolder = parsedLinux == "/" ? "" : parsedLinux;
+            }
+            else if (!string.IsNullOrEmpty(target.WorkingFolder) && target.WorkingFolder.StartsWith('/'))
+            {
+                // Caller passed a Linux path directly (e.g. typed into a worktree dialog).
+                target.WslWorkingFolder = target.WorkingFolder;
+                target.WorkingFolder = Services.WslDiscoveryService.ToUncPath(
+                    source.WslDistro, target.WslWorkingFolder);
+            }
+            else
+            {
+                // Unknown shape — keep the parent's folder so the child at least lands
+                // somewhere usable instead of in $HOME-by-accident.
+                target.WslWorkingFolder = source.WslWorkingFolder;
+                target.WorkingFolder = source.WorkingFolder;
+            }
+        }
+    }
+
+    /// <summary>
     /// Launches a new session in an existing sibling worktree (path resolved via
     /// `git worktree list`). Inherits the source session's command, group, and profile.
     /// </summary>
@@ -695,6 +732,7 @@ public partial class MainWindow : Window
             string.IsNullOrEmpty(p.GroupId) ? null : p.GroupId,
             colorOverride: null,
             afterSessionId: parent.Id);
+        InheritSessionKindFrom(sibling, p);
         sibling.ProfileFontFamily = p.ProfileFontFamily;
         sibling.ProfileFontSize = p.ProfileFontSize;
         sibling.ProfileFontWeight = p.ProfileFontWeight;
@@ -2973,6 +3011,7 @@ public partial class MainWindow : Window
             source.Session.Args,
             string.IsNullOrEmpty(source.Session.GroupId) ? null : source.Session.GroupId,
             source.Session.ColorOverride);
+        InheritSessionKindFrom(newSession, source.Session);
         newSession.ProfileFontFamily = source.Session.ProfileFontFamily;
         newSession.ProfileFontSize = source.Session.ProfileFontSize;
         newSession.ProfileFontWeight = source.Session.ProfileFontWeight;

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -507,11 +507,19 @@ public partial class MainWindow : Window
             string.IsNullOrEmpty(entry.GroupId) ? null : entry.GroupId,
             colorOverride: entry.ColorOverride);
 
-        session.IsRemote = entry.IsRemote;
+        // Kind first so the IsRemote shim below doesn't promote a Wsl entry back
+        // to Ssh when its IsRemote happens to round-trip as false.
+        session.Kind = entry.Kind;
+        // Legacy entries (pre-Kind) have Kind=Local but IsRemote=true for SSH —
+        // the IsRemote setter on ShellSession migrates that to Kind=Ssh.
+        if (entry.Kind == Models.SessionKind.Local) session.IsRemote = entry.IsRemote;
         session.SshUser = entry.SshUser;
         session.SshHost = entry.SshHost;
         session.SshPort = entry.SshPort;
         session.SshRemoteFolder = entry.SshRemoteFolder;
+        session.WslDistro = entry.WslDistro;
+        session.WslUser = entry.WslUser;
+        session.WslWorkingFolder = entry.WslWorkingFolder;
 
         session.ProfileFontFamily = entry.ProfileFontFamily;
         session.ProfileFontSize = entry.ProfileFontSize;

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -455,11 +455,23 @@ public partial class MainWindow : Window
 
         if (dialog.IsRemote)
         {
-            session.IsRemote = true;
+            session.Kind = Models.SessionKind.Ssh;
             session.SshUser = dialog.SshUser;
             session.SshHost = dialog.SshHost;
             session.SshPort = dialog.SshPort;
             session.SshRemoteFolder = dialog.SshRemoteFolder;
+        }
+        else if (dialog.IsWsl)
+        {
+            session.Kind = Models.SessionKind.Wsl;
+            session.WslDistro = dialog.WslDistro;
+            session.WslUser = dialog.WslUser;
+            session.WslWorkingFolder = dialog.WslWorkingFolder;
+            // The session's WorkingFolder stays as a Windows UNC view of the same path
+            // so anything that touches the filesystem (git status, "open in Explorer")
+            // resolves correctly. Empty = unmounted; LaunchSessionAsync falls back.
+            session.WorkingFolder = Services.WslDiscoveryService.ToUncPath(
+                dialog.WslDistro, dialog.WslWorkingFolder);
         }
 
         // Profile overrides come from the dialog (which may have copied from a Windows Terminal
@@ -603,13 +615,19 @@ public partial class MainWindow : Window
             string.IsNullOrEmpty(p.GroupId) ? null : p.GroupId,
             colorOverride: null,
             afterSessionId: parent.Id);
-        if (p.IsRemote)
+        clone.Kind = p.Kind;
+        if (p.Kind == Models.SessionKind.Ssh)
         {
-            clone.IsRemote = true;
             clone.SshUser = p.SshUser;
             clone.SshHost = p.SshHost;
             clone.SshPort = p.SshPort;
             clone.SshRemoteFolder = p.SshRemoteFolder;
+        }
+        else if (p.Kind == Models.SessionKind.Wsl)
+        {
+            clone.WslDistro = p.WslDistro;
+            clone.WslUser = p.WslUser;
+            clone.WslWorkingFolder = p.WslWorkingFolder;
         }
         clone.ProfileFontFamily = p.ProfileFontFamily;
         clone.ProfileFontSize = p.ProfileFontSize;
@@ -698,7 +716,9 @@ public partial class MainWindow : Window
     /// </summary>
     private void SeedRunCommandsAsync(Models.ShellSession session)
     {
-        if (session.IsRemote) return;
+        // Templates are local-only — SSH and WSL working folders are out of reach for
+        // the synchronous Directory.EnumerateFiles probe in RunCommandTemplatesService.
+        if (session.Kind != Models.SessionKind.Local) return;
         if (session.RunCommands.Count > 0) return;
         if (string.IsNullOrWhiteSpace(session.WorkingFolder)) return;
 
@@ -1038,10 +1058,19 @@ public partial class MainWindow : Window
         string effectiveArgs;
         string workDir;
 
-        if (session.IsRemote)
+        if (session.Kind == Models.SessionKind.Ssh)
         {
             effectiveCommand = "ssh";
             effectiveArgs = session.BuildSshArgs();
+            workDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+        else if (session.Kind == Models.SessionKind.Wsl)
+        {
+            // wsl.exe handles its own cwd via --cd inside BuildWslArgs; pass the user
+            // profile as the launching process's cwd so CreateProcess never sees a UNC
+            // path it might reject.
+            effectiveCommand = "wsl.exe";
+            effectiveArgs = session.BuildWslArgs();
             workDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         }
         else
@@ -4157,9 +4186,7 @@ public partial class MainWindow : Window
         var textPanel = new StackPanel { Margin = new Thickness(8, 6, 4, 6) };
 
         string displayName = string.IsNullOrWhiteSpace(session.Name)
-            ? (session.IsRemote
-                ? (string.IsNullOrWhiteSpace(session.SshHost) ? session.Command : session.SshHost)
-                : System.IO.Path.GetFileName(session.WorkingFolder.TrimEnd('/', '\\')) ?? session.Command)
+            ? session.DefaultDisplayName
             : session.Name;
 
         var nameText = new TextBlock
@@ -4171,11 +4198,7 @@ public partial class MainWindow : Window
             TextTrimming = TextTrimming.CharacterEllipsis
         };
 
-        string folderShort = session.IsRemote
-            ? (string.IsNullOrWhiteSpace(session.SshHost) ? "" : session.SshHost)
-            : (string.IsNullOrEmpty(session.WorkingFolder)
-                ? ""
-                : new System.IO.DirectoryInfo(session.WorkingFolder).Name);
+        string folderShort = session.FolderShort;
 
         var folderText = new TextBlock
         {
@@ -4252,9 +4275,7 @@ public partial class MainWindow : Window
         var textPanel = new StackPanel { Margin = new Thickness(8, 6, 4, 6) };
 
         string displayName = string.IsNullOrWhiteSpace(session.Name)
-            ? (session.IsRemote
-                ? (string.IsNullOrWhiteSpace(session.SshHost) ? session.Command : session.SshHost)
-                : System.IO.Path.GetFileName(session.WorkingFolder.TrimEnd('/', '\\')) ?? session.Command)
+            ? session.DefaultDisplayName
             : session.Name;
 
         var nameText = new TextBlock
@@ -4266,11 +4287,7 @@ public partial class MainWindow : Window
             TextTrimming = TextTrimming.CharacterEllipsis
         };
 
-        string folderShort = session.IsRemote
-            ? (string.IsNullOrWhiteSpace(session.SshHost) ? "" : session.SshHost)
-            : (string.IsNullOrEmpty(session.WorkingFolder)
-                ? ""
-                : new System.IO.DirectoryInfo(session.WorkingFolder).Name);
+        string folderShort = session.FolderShort;
 
         var folderText = new TextBlock
         {
@@ -4358,10 +4375,7 @@ public partial class MainWindow : Window
     }
 
     private static string GetAccentForSession(ShellSession s) =>
-        s.ColorOverride ?? ColorService.GetHexColor(
-            s.IsRemote
-                ? (string.IsNullOrWhiteSpace(s.SshUser) ? s.SshHost : $"{s.SshUser}@{s.SshHost}")
-                : s.WorkingFolder);
+        s.ColorOverride ?? ColorService.GetHexColor(s.AccentKey);
 
     // ── Search ────────────────────────────────────────────────────────────────
 

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -2779,6 +2779,13 @@ public partial class MainWindow : Window
                 var psItem = new System.Windows.Controls.MenuItem { Header = "Open PowerShell here" };
                 psItem.Click += (_, _) => LaunchPowerShellInFolder(vm.WorkingFolder, vm.GroupId);
                 menu.Items.Add(psItem);
+
+                if (vm.Session.IsWsl)
+                {
+                    var wslConsoleItem = new System.Windows.Controls.MenuItem { Header = "Open WSL console here" };
+                    wslConsoleItem.Click += (_, _) => LaunchWslConsoleFromSession(vm.Session);
+                    menu.Items.Add(wslConsoleItem);
+                }
             }
 
             menu.Items.Add(new System.Windows.Controls.Separator());
@@ -4562,6 +4569,27 @@ public partial class MainWindow : Window
 
         var session = _sessionManager.CreateSession(folderName, workingFolder, cmd, "", groupId);
         SeedRunCommandsAsync(session);
+        _ = LaunchSessionAsync(session);
+    }
+
+    /// <summary>
+    /// WSL counterpart of <see cref="LaunchPowerShellInFolder"/>: spawns a bare bash
+    /// session inside the same distro + Linux folder as <paramref name="parent"/>.
+    /// Used by the "Open WSL console here" context-menu item.
+    /// </summary>
+    private void LaunchWslConsoleFromSession(Models.ShellSession parent)
+    {
+        if (!parent.IsWsl) return;
+        string leaf = string.IsNullOrEmpty(parent.WslWorkingFolder)
+            ? parent.WslDistro
+            : System.IO.Path.GetFileName(parent.WslWorkingFolder.TrimEnd('/'));
+        string name = string.IsNullOrEmpty(leaf) ? "bash" : $"{leaf} (bash)";
+
+        var session = _sessionManager.CreateSession(name, parent.WorkingFolder, "bash", "", parent.GroupId);
+        session.Kind = Models.SessionKind.Wsl;
+        session.WslDistro = parent.WslDistro;
+        session.WslUser = parent.WslUser;
+        session.WslWorkingFolder = parent.WslWorkingFolder;
         _ = LaunchSessionAsync(session);
     }
 

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -406,7 +406,8 @@ public partial class MainWindow : Window
             defaultCommand: parent?.Session.Command,
             defaultArgs: parent?.Session.Args,
             defaultName: null,
-            recentlyClosed: _vm.RecentlyClosed)
+            recentlyClosed: _vm.RecentlyClosed,
+            defaultSourceSession: parent?.Session)
         {
             Owner = this
         };

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -755,9 +755,12 @@ public partial class MainWindow : Window
     /// </summary>
     private void SeedRunCommandsAsync(Models.ShellSession session)
     {
-        // Templates are local-only — SSH and WSL working folders are out of reach for
-        // the synchronous Directory.EnumerateFiles probe in RunCommandTemplatesService.
-        if (session.Kind != Models.SessionKind.Local) return;
+        // SSH is out of reach for the synchronous Directory.EnumerateFiles probe.
+        // WSL is reachable via the `\\wsl$\<distro>\…` UNC view — slow on first
+        // access if the distro VM is stopped, but the probe runs on a background
+        // task so the UI doesn't block. RunInstance already wraps run commands in
+        // `wsl.exe -- bash -lc` for WSL parents.
+        if (session.Kind == Models.SessionKind.Ssh) return;
         if (session.RunCommands.Count > 0) return;
         if (string.IsNullOrWhiteSpace(session.WorkingFolder)) return;
 

--- a/src/CodeShellManager/Models/RecentlyClosedEntry.cs
+++ b/src/CodeShellManager/Models/RecentlyClosedEntry.cs
@@ -23,11 +23,28 @@ public class RecentlyClosedEntry
     public string GroupId { get; set; } = "";
     public string? ColorOverride { get; set; }
 
-    public bool IsRemote { get; set; }
+    /// <summary>
+    /// Kind of the closed session — needed so a reopened WSL session comes back
+    /// as WSL instead of falling back to Local at the UNC path. Mirrors the
+    /// <see cref="ShellSession.IsRemote"/> migration: setting <see cref="IsRemote"/>
+    /// to true promotes <c>Local → Ssh</c>, so legacy state.json entries (which
+    /// only carried IsRemote) still display the right subtitle and reopen as SSH.
+    /// </summary>
+    public SessionKind Kind { get; set; } = SessionKind.Local;
+
+    public bool IsRemote
+    {
+        get => Kind == SessionKind.Ssh;
+        set { if (value && Kind == SessionKind.Local) Kind = SessionKind.Ssh; }
+    }
     public string SshUser { get; set; } = "";
     public string SshHost { get; set; } = "";
     public int SshPort { get; set; } = 22;
     public string SshRemoteFolder { get; set; } = "";
+
+    public string WslDistro { get; set; } = "";
+    public string WslUser { get; set; } = "";
+    public string WslWorkingFolder { get; set; } = "";
 
     public string? ProfileFontFamily { get; set; }
     public int? ProfileFontSize { get; set; }
@@ -57,11 +74,15 @@ public class RecentlyClosedEntry
         Args = s.Args,
         GroupId = s.GroupId,
         ColorOverride = s.ColorOverride,
+        Kind = s.Kind,
         IsRemote = s.IsRemote,
         SshUser = s.SshUser,
         SshHost = s.SshHost,
         SshPort = s.SshPort,
         SshRemoteFolder = s.SshRemoteFolder,
+        WslDistro = s.WslDistro,
+        WslUser = s.WslUser,
+        WslWorkingFolder = s.WslWorkingFolder,
         ProfileFontFamily = s.ProfileFontFamily,
         ProfileFontSize = s.ProfileFontSize,
         ProfileFontWeight = s.ProfileFontWeight,
@@ -84,8 +105,13 @@ public class RecentlyClosedEntry
         ClosedAt = DateTime.UtcNow,
     };
 
-    /// <summary>Friendly subtitle for the recents UI — folder or user@host.</summary>
-    public string Subtitle => IsRemote
-        ? (string.IsNullOrWhiteSpace(SshUser) ? SshHost : $"{SshUser}@{SshHost}")
-        : WorkingFolder;
+    /// <summary>Friendly subtitle for the recents UI — kind-specific locator.</summary>
+    public string Subtitle => Kind switch
+    {
+        SessionKind.Ssh => string.IsNullOrWhiteSpace(SshUser) ? SshHost : $"{SshUser}@{SshHost}",
+        SessionKind.Wsl => string.IsNullOrEmpty(WslWorkingFolder)
+            ? WslDistro
+            : $"{WslDistro}: {WslWorkingFolder}",
+        _ => WorkingFolder,
+    };
 }

--- a/src/CodeShellManager/Models/ShellSession.cs
+++ b/src/CodeShellManager/Models/ShellSession.cs
@@ -6,6 +6,13 @@ namespace CodeShellManager.Models;
 
 public enum SessionStatus { Idle, Running, NeedsAttention, Exited }
 
+/// <summary>
+/// Kind of pseudo-terminal session. <see cref="Local"/> runs a Windows process directly,
+/// <see cref="Ssh"/> tunnels through the system ssh client, <see cref="Wsl"/> launches
+/// a shell inside a WSL distro via <c>wsl.exe</c>.
+/// </summary>
+public enum SessionKind { Local, Ssh, Wsl }
+
 public class ShellSession
 {
     public string Id { get; set; } = Guid.NewGuid().ToString();
@@ -34,12 +41,40 @@ public class ShellSession
     /// </summary>
     public bool IsDormant { get; set; }
 
+    /// <summary>
+    /// Authoritative session kind. New code reads this; <see cref="IsRemote"/> is kept
+    /// as a back-compat shim so legacy state.json (which only carried the SSH boolean)
+    /// continues to deserialize: on load, <c>IsRemote=true</c> promotes <c>Kind</c> to
+    /// <see cref="SessionKind.Ssh"/>.
+    /// </summary>
+    public SessionKind Kind { get; set; } = SessionKind.Local;
+
     // SSH / remote session fields
-    public bool IsRemote { get; set; }
+    /// <summary>
+    /// Legacy SSH flag — true iff <see cref="Kind"/> is <see cref="SessionKind.Ssh"/>.
+    /// Kept as a property (not just a computed getter) so old state.json files with
+    /// <c>"IsRemote": true</c> and no <c>Kind</c> key still migrate cleanly on
+    /// deserialization. The setter only promotes <c>Local → Ssh</c>; it never clears
+    /// <c>Kind</c>, so a JSON document with both <c>IsRemote</c> and <c>Kind</c>
+    /// (deserialized in any order) lands on the correct value.
+    /// </summary>
+    public bool IsRemote
+    {
+        get => Kind == SessionKind.Ssh;
+        set { if (value && Kind == SessionKind.Local) Kind = SessionKind.Ssh; }
+    }
     public string SshUser { get; set; } = "";
     public string SshHost { get; set; } = "";
     public int SshPort { get; set; } = 22;
     public string SshRemoteFolder { get; set; } = "";
+
+    // WSL session fields
+    /// <summary>Name of the WSL distro (matches <c>wsl -l -q</c>), e.g. "Ubuntu".</summary>
+    public string WslDistro { get; set; } = "";
+    /// <summary>Optional WSL user override (<c>wsl -u &lt;user&gt;</c>). Empty = the distro's default user.</summary>
+    public string WslUser { get; set; } = "";
+    /// <summary>Linux-style working folder inside the distro, e.g. "/home/alice/project". Empty = the user's home.</summary>
+    public string WslWorkingFolder { get; set; } = "";
 
     // Per-session appearance overrides (typically populated from a Windows
     // Terminal profile via NewSessionDialog). All nullable — null means "use the
@@ -66,11 +101,12 @@ public class ShellSession
     public List<RunCommandItem> RunCommands { get; set; } = new();
 
     // Full command line for display and passthrough.
-    // For remote sessions: "ssh <BuildSshArgs()>"
-    // For local sessions: "Command [Args]"
-    public string FullCommandLine => IsRemote
-        ? $"ssh {BuildSshArgs()}"
-        : (string.IsNullOrWhiteSpace(Args) ? Command : $"{Command} {Args}");
+    public string FullCommandLine => Kind switch
+    {
+        SessionKind.Ssh => $"ssh {BuildSshArgs()}",
+        SessionKind.Wsl => $"wsl.exe {BuildWslArgs()}",
+        _ => string.IsNullOrWhiteSpace(Args) ? Command : $"{Command} {Args}",
+    };
 
     /// <summary>
     /// Builds the argument string passed to the ssh executable.
@@ -95,5 +131,83 @@ public class ShellSession
             sb.Append($" {Args}");
         sb.Append("\"");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds the argument string passed to wsl.exe.
+    /// Example: "-d Ubuntu -u alice --cd /home/alice/project -- bash -lc \"claude\""
+    /// The command is wrapped in <c>bash -lc</c> so PATH-resolved tools (nvm-managed
+    /// node, pyenv, etc.) work the same as in a user-launched login shell.
+    /// </summary>
+    internal string BuildWslArgs()
+    {
+        if (string.IsNullOrWhiteSpace(WslDistro))
+            throw new InvalidOperationException("WslDistro must be set for WSL sessions.");
+        var sb = new StringBuilder();
+        sb.Append($"-d {WslDistro}");
+        if (!string.IsNullOrWhiteSpace(WslUser))
+            sb.Append($" -u {WslUser}");
+        if (!string.IsNullOrWhiteSpace(WslWorkingFolder))
+            sb.Append($" --cd {WslWorkingFolder}");
+        var shell = string.IsNullOrWhiteSpace(Command) ? "bash" : Command;
+        string inner = string.IsNullOrWhiteSpace(Args) ? shell : $"{shell} {Args}";
+        sb.Append($" -- bash -lc \"{inner.Replace("\"", "\\\"")}\"");
+        return sb.ToString();
+    }
+
+    // ── Display helpers (single source of truth — see MainWindow sidebar / VM) ────
+
+    /// <summary>
+    /// Subtitle-line text for the sidebar: a short, kind-appropriate locator.
+    /// Local → working folder leaf; Ssh → host; Wsl → <c>distro:linux-leaf</c>.
+    /// </summary>
+    public string FolderShort => Kind switch
+    {
+        SessionKind.Ssh => string.IsNullOrWhiteSpace(SshHost) ? "" : SshHost,
+        SessionKind.Wsl => BuildWslFolderShort(),
+        _ => string.IsNullOrEmpty(WorkingFolder)
+            ? ""
+            : new System.IO.DirectoryInfo(WorkingFolder).Name,
+    };
+
+    /// <summary>
+    /// What to show as the session's label when <see cref="Name"/> is blank.
+    /// </summary>
+    public string DefaultDisplayName => Kind switch
+    {
+        SessionKind.Ssh => string.IsNullOrWhiteSpace(SshHost) ? Command : SshHost,
+        SessionKind.Wsl => string.IsNullOrWhiteSpace(WslDistro)
+            ? Command
+            : (string.IsNullOrEmpty(WslWorkingFolder)
+                ? WslDistro
+                : $"{WslDistro}: {LeafName(WslWorkingFolder)}"),
+        _ => System.IO.Path.GetFileName(WorkingFolder.TrimEnd('/', '\\')) ?? Command,
+    };
+
+    /// <summary>
+    /// Key used by ColorService to pick a deterministic accent color. Worktree
+    /// siblings share an accent via the repo-root override done in <see cref="ViewModels.SessionViewModel.AccentColor"/>;
+    /// this is the base key when no repo-root is known.
+    /// </summary>
+    public string AccentKey => Kind switch
+    {
+        SessionKind.Ssh => string.IsNullOrWhiteSpace(SshUser) ? SshHost : $"{SshUser}@{SshHost}",
+        SessionKind.Wsl => $"wsl://{WslDistro}{WslWorkingFolder}",
+        _ => WorkingFolder,
+    };
+
+    private string BuildWslFolderShort()
+    {
+        if (string.IsNullOrWhiteSpace(WslDistro)) return "";
+        string leaf = LeafName(WslWorkingFolder);
+        return string.IsNullOrEmpty(leaf) ? WslDistro : $"{WslDistro}: {leaf}";
+    }
+
+    private static string LeafName(string linuxPath)
+    {
+        if (string.IsNullOrWhiteSpace(linuxPath)) return "";
+        string trimmed = linuxPath.TrimEnd('/');
+        int slash = trimmed.LastIndexOf('/');
+        return slash >= 0 ? trimmed[(slash + 1)..] : trimmed;
     }
 }

--- a/src/CodeShellManager/Models/ShellSession.cs
+++ b/src/CodeShellManager/Models/ShellSession.cs
@@ -140,22 +140,37 @@ public class ShellSession
     /// Builds the argument string passed to wsl.exe.
     /// Example: "-d Ubuntu -u alice --cd /home/alice/project -- bash -lc \"claude\""
     /// The command is wrapped in <c>bash -lc</c> so PATH-resolved tools (nvm-managed
-    /// node, pyenv, etc.) work the same as in a user-launched login shell.
+    /// node, pyenv, etc.) work the same as in a user-launched login shell. Distro,
+    /// user, and working-folder values are passed through <see cref="QuoteForCmd"/>
+    /// so values containing spaces (Linux paths often do) survive Win32 arg parsing.
     /// </summary>
     internal string BuildWslArgs()
     {
         if (string.IsNullOrWhiteSpace(WslDistro))
             throw new InvalidOperationException("WslDistro must be set for WSL sessions.");
         var sb = new StringBuilder();
-        sb.Append($"-d {WslDistro}");
+        sb.Append($"-d {QuoteForCmd(WslDistro)}");
         if (!string.IsNullOrWhiteSpace(WslUser))
-            sb.Append($" -u {WslUser}");
+            sb.Append($" -u {QuoteForCmd(WslUser)}");
         if (!string.IsNullOrWhiteSpace(WslWorkingFolder))
-            sb.Append($" --cd {WslWorkingFolder}");
+            sb.Append($" --cd {QuoteForCmd(WslWorkingFolder)}");
         var shell = string.IsNullOrWhiteSpace(Command) ? "bash" : Command;
         string inner = string.IsNullOrWhiteSpace(Args) ? shell : $"{shell} {Args}";
         sb.Append($" -- bash -lc \"{inner.Replace("\"", "\\\"")}\"");
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Conservative Win32 command-line quoting: leaves space-free, quote-free values
+    /// alone (so existing call sites and tests don't regress) and wraps anything else
+    /// in double quotes with embedded <c>"</c> escaped as <c>\"</c>. Used by the WSL
+    /// arg builders (here and in <c>RunInstance</c>) and GitService's wsl.exe routing.
+    /// </summary>
+    internal static string QuoteForCmd(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return "\"\"";
+        if (value.IndexOfAny(new[] { ' ', '\t', '"' }) < 0) return value;
+        return "\"" + value.Replace("\"", "\\\"") + "\"";
     }
 
     // ── Display helpers (single source of truth — see MainWindow sidebar / VM) ────

--- a/src/CodeShellManager/Models/ShellSession.cs
+++ b/src/CodeShellManager/Models/ShellSession.cs
@@ -51,7 +51,7 @@ public class ShellSession
 
     // SSH / remote session fields
     /// <summary>
-    /// Legacy SSH flag — true iff <see cref="Kind"/> is <see cref="SessionKind.Ssh"/>.
+    /// SSH flag — true iff <see cref="Kind"/> is <see cref="SessionKind.Ssh"/>.
     /// Kept as a property (not just a computed getter) so old state.json files with
     /// <c>"IsRemote": true</c> and no <c>Kind</c> key still migrate cleanly on
     /// deserialization. The setter only promotes <c>Local → Ssh</c>; it never clears
@@ -63,6 +63,9 @@ public class ShellSession
         get => Kind == SessionKind.Ssh;
         set { if (value && Kind == SessionKind.Local) Kind = SessionKind.Ssh; }
     }
+
+    /// <summary>True iff this session runs inside a WSL distro via wsl.exe.</summary>
+    public bool IsWsl => Kind == SessionKind.Wsl;
     public string SshUser { get; set; } = "";
     public string SshHost { get; set; } = "";
     public int SshPort { get; set; } = 22;

--- a/src/CodeShellManager/Models/ShellSession.cs
+++ b/src/CodeShellManager/Models/ShellSession.cs
@@ -198,7 +198,7 @@ public class ShellSession
             ? Command
             : (string.IsNullOrEmpty(WslWorkingFolder)
                 ? WslDistro
-                : $"{WslDistro}: {LeafName(WslWorkingFolder)}"),
+                : $"{WslDistro}: {System.IO.Path.GetFileName(WslWorkingFolder.TrimEnd('/'))}"),
         _ => System.IO.Path.GetFileName(WorkingFolder.TrimEnd('/', '\\')) ?? Command,
     };
 
@@ -217,15 +217,11 @@ public class ShellSession
     private string BuildWslFolderShort()
     {
         if (string.IsNullOrWhiteSpace(WslDistro)) return "";
-        string leaf = LeafName(WslWorkingFolder);
+        // Path.GetFileName understands both separators on Windows and returns ""
+        // for empty input, so it covers our "WslWorkingFolder might be blank" case.
+        string leaf = string.IsNullOrWhiteSpace(WslWorkingFolder)
+            ? ""
+            : System.IO.Path.GetFileName(WslWorkingFolder.TrimEnd('/'));
         return string.IsNullOrEmpty(leaf) ? WslDistro : $"{WslDistro}: {leaf}";
-    }
-
-    private static string LeafName(string linuxPath)
-    {
-        if (string.IsNullOrWhiteSpace(linuxPath)) return "";
-        string trimmed = linuxPath.TrimEnd('/');
-        int slash = trimmed.LastIndexOf('/');
-        return slash >= 0 ? trimmed[(slash + 1)..] : trimmed;
     }
 }

--- a/src/CodeShellManager/Services/GitService.cs
+++ b/src/CodeShellManager/Services/GitService.cs
@@ -214,10 +214,10 @@ public static class GitService
         string distro, string linuxPath, string arguments, int timeoutMs)
     {
         string translatedArgs = TranslateUncArgsToLinux(arguments, distro);
-        // Use double quotes around the cwd — wsl.exe + Linux git both accept them and
-        // it sidesteps the apostrophe-in-path footgun that single quotes would have.
+        // QuoteForCmd handles spaces in both the distro name (rare) and the cwd
+        // (Linux paths often have them) without disturbing the simple-name case.
         string cwd = string.IsNullOrEmpty(linuxPath) ? "/" : linuxPath;
-        string args = $"-d {distro} -- git -C \"{cwd}\" {translatedArgs}";
+        string args = $"-d {Models.ShellSession.QuoteForCmd(distro)} -- git -C {Models.ShellSession.QuoteForCmd(cwd)} {translatedArgs}";
 
         var psi = new ProcessStartInfo("wsl.exe")
         {

--- a/src/CodeShellManager/Services/GitService.cs
+++ b/src/CodeShellManager/Services/GitService.cs
@@ -310,7 +310,13 @@ public static class GitService
     internal static string TranslateLinuxPathsToUnc(string text, string distro)
     {
         if (string.IsNullOrEmpty(text)) return text;
-        return Regex.Replace(text, @"(^|[\s=:])(/[^\s'""<>|]+)", m =>
+        // Tail used to stop at any whitespace, which mangled paths containing spaces
+        // (`/home/alice/My Projects/proj` came back as `\\wsl$\Ubuntu\home\alice\My`
+        // with the rest left as forward-slashed garbage). Our callers (rev-parse,
+        // worktree list --porcelain) always emit the path as the full remainder of
+        // the line, so widening the tail to "anything but newline / shell-meta" is
+        // safe and recovers space-containing paths correctly.
+        return Regex.Replace(text, @"(^|[\s=:])(/[^\r\n'""<>|]+)", m =>
         {
             string linuxPath = m.Groups[2].Value;
             string unc = $@"\\wsl$\{distro}" + linuxPath.Replace('/', '\\');

--- a/src/CodeShellManager/Services/GitService.cs
+++ b/src/CodeShellManager/Services/GitService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace CodeShellManager.Services;
@@ -166,6 +168,13 @@ public static class GitService
     private static async Task<(string stdout, string stderr, int exit)> RunGitFullAsync(
         string workingDir, string arguments, int timeoutMs)
     {
+        // WSL working folders (\\wsl$\<distro>\…) get routed through wsl.exe so git
+        // runs inside the distro. Git for Windows trips on WSL UNCs (dubious-ownership
+        // checks, .git symlink quirks) and reports "not a git repo" for valid repos.
+        var (wslDistro, linuxPath) = TryParseWslUnc(workingDir);
+        if (wslDistro != null)
+            return await RunGitInWslAsync(wslDistro, linuxPath, arguments, timeoutMs);
+
         var psi = new ProcessStartInfo("git")
         {
             Arguments = $"-C \"{workingDir}\" {arguments}",
@@ -192,5 +201,107 @@ public static class GitService
         string stdout = outTask.IsCompletedSuccessfully ? outTask.Result : "";
         string stderr = errTask.IsCompletedSuccessfully ? errTask.Result : "";
         return (stdout, stderr, process.HasExited ? process.ExitCode : -1);
+    }
+
+    /// <summary>
+    /// Runs <c>wsl.exe -d &lt;distro&gt; -- git -C &lt;linuxPath&gt; &lt;arguments&gt;</c>.
+    /// Translates any WSL UNC paths in <paramref name="arguments"/> to Linux form
+    /// before invocation (so things like <c>worktree add "\\wsl$\Ubuntu\…"</c> reach
+    /// git as a normal Linux path), and translates absolute Linux paths in stdout
+    /// back to UNC form so callers receive Windows-shaped paths.
+    /// </summary>
+    private static async Task<(string stdout, string stderr, int exit)> RunGitInWslAsync(
+        string distro, string linuxPath, string arguments, int timeoutMs)
+    {
+        string translatedArgs = TranslateUncArgsToLinux(arguments, distro);
+        // Use double quotes around the cwd — wsl.exe + Linux git both accept them and
+        // it sidesteps the apostrophe-in-path footgun that single quotes would have.
+        string cwd = string.IsNullOrEmpty(linuxPath) ? "/" : linuxPath;
+        string args = $"-d {distro} -- git -C \"{cwd}\" {translatedArgs}";
+
+        var psi = new ProcessStartInfo("wsl.exe")
+        {
+            Arguments = args,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+
+        using var process = Process.Start(psi);
+        if (process is null) return ("", "", -1);
+
+        var outTask = process.StandardOutput.ReadToEndAsync();
+        var errTask = process.StandardError.ReadToEndAsync();
+        var bothTask = Task.WhenAll(outTask, errTask);
+        var completed = await Task.WhenAny(bothTask, Task.Delay(timeoutMs));
+        if (completed != bothTask) { try { process.Kill(); } catch { } }
+        try { await process.WaitForExitAsync(); } catch { }
+
+        string stdout = outTask.IsCompletedSuccessfully ? outTask.Result : "";
+        string stderr = errTask.IsCompletedSuccessfully ? errTask.Result : "";
+        stdout = TranslateLinuxPathsToUnc(stdout, distro);
+        return (stdout, stderr, process.HasExited ? process.ExitCode : -1);
+    }
+
+    /// <summary>
+    /// Detects a <c>\\wsl$\&lt;distro&gt;\…</c> or <c>\\wsl.localhost\&lt;distro&gt;\…</c>
+    /// path and splits it into (distro, linux-path). Returns (null, "") otherwise.
+    /// </summary>
+    internal static (string? distro, string linuxPath) TryParseWslUnc(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return (null, "");
+        string normalized = path.Replace('/', '\\').TrimEnd('\\');
+        string[] prefixes = { @"\\wsl$\", @"\\wsl.localhost\" };
+        foreach (var prefix in prefixes)
+        {
+            if (!normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+            string rest = normalized[prefix.Length..];
+            if (string.IsNullOrEmpty(rest)) return (null, "");
+            int slash = rest.IndexOf('\\');
+            string distro = slash < 0 ? rest : rest[..slash];
+            string linuxRest = slash < 0 ? "" : rest[(slash + 1)..];
+            string linuxPath = string.IsNullOrEmpty(linuxRest) ? "/" : "/" + linuxRest.Replace('\\', '/');
+            return (distro, linuxPath);
+        }
+        return (null, "");
+    }
+
+    /// <summary>
+    /// Replaces WSL UNC tokens in a git arg string with their Linux equivalents.
+    /// Only translates UNCs that belong to <paramref name="distro"/> — a UNC for a
+    /// different distro is passed through unchanged (so the caller sees the eventual
+    /// "no such directory" error rather than silently aiming at the wrong tree).
+    /// </summary>
+    internal static string TranslateUncArgsToLinux(string arguments, string distro)
+    {
+        if (string.IsNullOrEmpty(arguments)) return arguments;
+        // Match \\wsl$\<distro>\<rest> or \\wsl.localhost\<distro>\<rest>; \<rest> is
+        // greedy up to the next quote/space (anything that would terminate a shell token).
+        var pattern = $@"\\\\wsl(?:\$|\.localhost)\\{Regex.Escape(distro)}(\\[^""\s]*)?";
+        return Regex.Replace(arguments, pattern, m =>
+        {
+            string tail = m.Groups[1].Value;
+            return string.IsNullOrEmpty(tail) ? "/" : tail.Replace('\\', '/');
+        }, RegexOptions.IgnoreCase);
+    }
+
+    /// <summary>
+    /// Replaces absolute Linux paths in <paramref name="text"/> (typically git stdout)
+    /// with <c>\\wsl$\&lt;distro&gt;\…</c> equivalents so callers see Windows-shaped
+    /// paths. Conservative — only matches tokens at start-of-line or after whitespace
+    /// to avoid mangling text that happens to contain a slash.
+    /// </summary>
+    internal static string TranslateLinuxPathsToUnc(string text, string distro)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        return Regex.Replace(text, @"(^|[\s=:])(/[^\s'""<>|]+)", m =>
+        {
+            string linuxPath = m.Groups[2].Value;
+            string unc = $@"\\wsl$\{distro}" + linuxPath.Replace('/', '\\');
+            return m.Groups[1].Value + unc;
+        }, RegexOptions.Multiline);
     }
 }

--- a/src/CodeShellManager/Services/GitService.cs
+++ b/src/CodeShellManager/Services/GitService.cs
@@ -278,14 +278,27 @@ public static class GitService
     internal static string TranslateUncArgsToLinux(string arguments, string distro)
     {
         if (string.IsNullOrEmpty(arguments)) return arguments;
-        // Match \\wsl$\<distro>\<rest> or \\wsl.localhost\<distro>\<rest>; \<rest> is
-        // greedy up to the next quote/space (anything that would terminate a shell token).
-        var pattern = $@"\\\\wsl(?:\$|\.localhost)\\{Regex.Escape(distro)}(\\[^""\s]*)?";
-        return Regex.Replace(arguments, pattern, m =>
+        string esc = Regex.Escape(distro);
+        string body = $@"\\\\wsl(?:\$|\.localhost)\\{esc}";
+
+        // Pass 1: quoted UNCs ("\\wsl$\<distro>\..."). The tail may contain spaces
+        // and runs until the closing quote — without this pass, the unquoted regex
+        // below would stop at the first space and produce a half-translated path.
+        arguments = Regex.Replace(arguments, $@"""({body}(?:\\[^""]*)?)""", m =>
         {
-            string tail = m.Groups[1].Value;
-            return string.IsNullOrEmpty(tail) ? "/" : tail.Replace('\\', '/');
+            var (_, linux) = TryParseWslUnc(m.Groups[1].Value);
+            return "\"" + (string.IsNullOrEmpty(linux) ? "/" : linux) + "\"";
         }, RegexOptions.IgnoreCase);
+
+        // Pass 2: unquoted UNCs. The tail runs to whitespace; if a path needed
+        // spaces it would have been quoted and handled above.
+        arguments = Regex.Replace(arguments, $@"{body}(?:\\[^""\s]*)?", m =>
+        {
+            var (_, linux) = TryParseWslUnc(m.Value);
+            return string.IsNullOrEmpty(linux) ? "/" : linux;
+        }, RegexOptions.IgnoreCase);
+
+        return arguments;
     }
 
     /// <summary>

--- a/src/CodeShellManager/Services/RunInstance.cs
+++ b/src/CodeShellManager/Services/RunInstance.cs
@@ -282,8 +282,16 @@ public partial class RunInstance : ObservableObject, IDisposable
             sb.Append($" -u {ShellSession.QuoteForCmd(parent.WslUser)}");
         if (!string.IsNullOrWhiteSpace(parent.WslWorkingFolder))
             sb.Append($" --cd {ShellSession.QuoteForCmd(parent.WslWorkingFolder)}");
-        sb.Append(" -- bash -lc ");
-        sb.Append(SingleQuoteEscape(commandLine));
+        // Use Windows-style double quotes here, NOT POSIX single quotes: wsl.exe is
+        // launched directly by CreateProcess (no outer shell), so Windows command-line
+        // tokenization runs first and only respects "..." for grouping. Single quotes
+        // would leak through literally — `bash -lc 'cargo test'` reaches bash split at
+        // the space into the two args `'cargo` and `test'`, and bash then chokes on
+        // the unbalanced quote. ShellSession.BuildWslArgs uses this same double-quote
+        // shape; we mirror it for parity.
+        sb.Append(" -- bash -lc \"");
+        sb.Append(commandLine.Replace("\"", "\\\""));
+        sb.Append("\"");
         return sb.ToString();
     }
 

--- a/src/CodeShellManager/Services/RunInstance.cs
+++ b/src/CodeShellManager/Services/RunInstance.cs
@@ -70,8 +70,9 @@ public partial class RunInstance : ObservableObject, IDisposable
     }
 
     /// <summary>
-    /// Spawns the child PTY. Builds the command line based on whether the parent
-    /// is local or remote — see <see cref="BuildLocalCmd"/> / <see cref="BuildSshArgs"/>.
+    /// Spawns the child PTY. Builds the command line based on the parent's
+    /// <see cref="ShellSession.Kind"/> — see <see cref="BuildLocalCmd"/>,
+    /// <see cref="BuildSshArgs"/>, and <see cref="BuildWslArgs"/>.
     /// </summary>
     public void Start(ShellSession parent)
     {
@@ -90,28 +91,36 @@ public partial class RunInstance : ObservableObject, IDisposable
         _pty.Exited += OnPtyExited;
 
         string command, args, workDir;
-        if (parent.IsRemote)
+        switch (parent.Kind)
         {
-            // SSH parents always go through bash — Mode is meaningless for remote runs.
-            command = "ssh";
-            args = BuildSshArgs(parent, CommandLine);
-            workDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        }
-        else if (Mode == RunMode.PowerShell)
-        {
-            command = ResolvePwsh();
-            args = BuildPwshArgs(CommandLine);
-            workDir = Directory.Exists(parent.WorkingFolder)
-                ? parent.WorkingFolder
-                : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        }
-        else
-        {
-            command = "cmd";
-            args = BuildLocalCmd(CommandLine);
-            workDir = Directory.Exists(parent.WorkingFolder)
-                ? parent.WorkingFolder
-                : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            case SessionKind.Ssh:
+                // SSH parents always go through bash — Mode is meaningless for remote runs.
+                command = "ssh";
+                args = BuildSshArgs(parent, CommandLine);
+                workDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                break;
+            case SessionKind.Wsl:
+                // WSL parents wrap the command in `wsl.exe … -- bash -lc` —
+                // running pwsh inside WSL is out of scope so Mode is ignored here too.
+                command = "wsl.exe";
+                args = BuildWslArgs(parent, CommandLine);
+                workDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                break;
+            default:
+                if (Mode == RunMode.PowerShell)
+                {
+                    command = ResolvePwsh();
+                    args = BuildPwshArgs(CommandLine);
+                }
+                else
+                {
+                    command = "cmd";
+                    args = BuildLocalCmd(CommandLine);
+                }
+                workDir = Directory.Exists(parent.WorkingFolder)
+                    ? parent.WorkingFolder
+                    : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                break;
         }
 
         _pty.Start(command, args, workDir, cols: 200, rows: 50, useJobObject: true);
@@ -258,6 +267,22 @@ public partial class RunInstance : ObservableObject, IDisposable
         sb.Append("bash -c ");
         sb.Append(SingleQuoteEscape(commandLine));
         sb.Append("\"");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds wsl.exe args for a run executed inside the parent's WSL distro. Pattern:
+    ///   -d &lt;distro&gt; [-u &lt;user&gt;] [--cd &lt;folder&gt;] -- bash -lc '&lt;escaped&gt;'
+    /// </summary>
+    internal static string BuildWslArgs(ShellSession parent, string commandLine)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"-d {parent.WslDistro}");
+        if (!string.IsNullOrWhiteSpace(parent.WslUser)) sb.Append($" -u {parent.WslUser}");
+        if (!string.IsNullOrWhiteSpace(parent.WslWorkingFolder))
+            sb.Append($" --cd {parent.WslWorkingFolder}");
+        sb.Append(" -- bash -lc ");
+        sb.Append(SingleQuoteEscape(commandLine));
         return sb.ToString();
     }
 

--- a/src/CodeShellManager/Services/RunInstance.cs
+++ b/src/CodeShellManager/Services/RunInstance.cs
@@ -277,10 +277,11 @@ public partial class RunInstance : ObservableObject, IDisposable
     internal static string BuildWslArgs(ShellSession parent, string commandLine)
     {
         var sb = new StringBuilder();
-        sb.Append($"-d {parent.WslDistro}");
-        if (!string.IsNullOrWhiteSpace(parent.WslUser)) sb.Append($" -u {parent.WslUser}");
+        sb.Append($"-d {ShellSession.QuoteForCmd(parent.WslDistro)}");
+        if (!string.IsNullOrWhiteSpace(parent.WslUser))
+            sb.Append($" -u {ShellSession.QuoteForCmd(parent.WslUser)}");
         if (!string.IsNullOrWhiteSpace(parent.WslWorkingFolder))
-            sb.Append($" --cd {parent.WslWorkingFolder}");
+            sb.Append($" --cd {ShellSession.QuoteForCmd(parent.WslWorkingFolder)}");
         sb.Append(" -- bash -lc ");
         sb.Append(SingleQuoteEscape(commandLine));
         return sb.ToString();

--- a/src/CodeShellManager/Services/WslDiscoveryService.cs
+++ b/src/CodeShellManager/Services/WslDiscoveryService.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CodeShellManager.Services;
+
+/// <summary>
+/// One installed WSL distro as reported by <c>wsl -l -v</c>.
+/// </summary>
+/// <param name="Name">Distro name (matches the <c>-d</c> argument to wsl.exe).</param>
+/// <param name="Version">WSL version (1 or 2). 0 if the column failed to parse.</param>
+/// <param name="IsDefault">True for the distro flagged with <c>*</c> in the listing.</param>
+/// <param name="State">Reported lifecycle state, e.g. "Running", "Stopped".</param>
+public record WslDistro(string Name, int Version, bool IsDefault, string State);
+
+/// <summary>
+/// Enumerates WSL distros installed on the current Windows host. Returns an empty list
+/// when wsl.exe is missing or returns an error (e.g. no distros installed).
+/// </summary>
+public static class WslDiscoveryService
+{
+    /// <summary>
+    /// Returns the currently installed distros. The result is suitable for populating
+    /// a UI picker; the default distro (if any) is marked via <see cref="WslDistro.IsDefault"/>.
+    /// Never throws — every failure mode collapses to an empty list.
+    /// </summary>
+    public static async Task<IReadOnlyList<WslDistro>> GetDistrosAsync()
+    {
+        if (!OperatingSystem.IsWindows()) return Array.Empty<WslDistro>();
+
+        try
+        {
+            var psi = new ProcessStartInfo("wsl.exe")
+            {
+                // -l -v is the verbose listing. --quiet is intentionally NOT used so we
+                // get the header row and the asterisk marker for the default distro.
+                Arguments = "-l -v",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                // wsl.exe writes its listings as UTF-16 LE (the same as PowerShell's
+                // default). Without this override we'd read each character interleaved
+                // with NUL bytes and the parser would see gibberish.
+                StandardOutputEncoding = Encoding.Unicode,
+                StandardErrorEncoding = Encoding.Unicode,
+            };
+
+            using var process = Process.Start(psi);
+            if (process is null) return Array.Empty<WslDistro>();
+
+            var outTask = process.StandardOutput.ReadToEndAsync();
+            var bothTask = Task.WhenAll(outTask, process.StandardError.ReadToEndAsync());
+            var completed = await Task.WhenAny(bothTask, Task.Delay(3000));
+            if (completed != bothTask)
+            {
+                try { process.Kill(); } catch { }
+                return Array.Empty<WslDistro>();
+            }
+            try { await process.WaitForExitAsync(); } catch { }
+            if (process.ExitCode != 0) return Array.Empty<WslDistro>();
+
+            return Parse(outTask.Result);
+        }
+        catch (Win32Exception)
+        {
+            // wsl.exe not on PATH — WSL feature isn't installed.
+            return Array.Empty<WslDistro>();
+        }
+        catch (FileNotFoundException)
+        {
+            return Array.Empty<WslDistro>();
+        }
+    }
+
+    /// <summary>
+    /// Parses the body of <c>wsl -l -v</c>. Exposed for testing.
+    /// </summary>
+    internal static IReadOnlyList<WslDistro> Parse(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return Array.Empty<WslDistro>();
+
+        var results = new List<WslDistro>();
+        foreach (var line in raw.Replace("\r", "").Split('\n'))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            // Header row: "  NAME                   STATE           VERSION".
+            // Detect by the presence of the literal "NAME" token and skip.
+            if (line.TrimStart().StartsWith("NAME", StringComparison.Ordinal)) continue;
+
+            var tokens = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (tokens.Length < 2) continue;
+
+            bool isDefault = tokens[0] == "*";
+            int idx = isDefault ? 1 : 0;
+            if (tokens.Length - idx < 1) continue;
+
+            string name = tokens[idx];
+            string state = tokens.Length - idx >= 2 ? tokens[idx + 1] : "";
+            int version = 0;
+            if (tokens.Length - idx >= 3) int.TryParse(tokens[idx + 2], out version);
+
+            results.Add(new WslDistro(name, version, isDefault, state));
+        }
+        // Stable ordering: default first, then alphabetical.
+        return results
+            .OrderByDescending(d => d.IsDefault)
+            .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Converts a WSL distro + Linux-style path to the Windows UNC view of that path
+    /// (<c>\\wsl$\Ubuntu\home\alice</c>). Used by GitService and PseudoTerminal's
+    /// working-directory argument so Windows-native tools can read the WSL filesystem.
+    /// Returns an empty string when either input is empty.
+    /// </summary>
+    public static string ToUncPath(string distro, string linuxPath)
+    {
+        if (string.IsNullOrWhiteSpace(distro)) return "";
+        if (string.IsNullOrWhiteSpace(linuxPath)) return $@"\\wsl$\{distro}";
+        string trimmed = linuxPath.TrimStart('/').Replace('/', '\\');
+        return $@"\\wsl$\{distro}\{trimmed}";
+    }
+}

--- a/src/CodeShellManager/Services/WslDiscoveryService.cs
+++ b/src/CodeShellManager/Services/WslDiscoveryService.cs
@@ -116,6 +116,59 @@ public static class WslDiscoveryService
     }
 
     /// <summary>
+    /// Resolves the home directory inside a WSL distro for the given user (or the distro's
+    /// default user when <paramref name="user"/> is null/empty). Cached per (distro, user) —
+    /// shells out once via <c>wsl -d &lt;distro&gt; [-u &lt;user&gt;] -- sh -c "cd ~ &amp;&amp; pwd"</c>
+    /// then returns the cached value on subsequent calls. Returns null on failure
+    /// (WSL not running, command timeout, or non-zero exit).
+    /// </summary>
+    public static async Task<string?> GetDistroHomeAsync(string distro, string? user = null)
+    {
+        if (string.IsNullOrWhiteSpace(distro)) return null;
+        string normalizedUser = user?.Trim() ?? "";
+        string key = $"{distro}|{normalizedUser}";
+        lock (_homeCache)
+        {
+            if (_homeCache.TryGetValue(key, out var cached)) return cached;
+        }
+
+        try
+        {
+            string args = $"-d {distro}";
+            if (!string.IsNullOrEmpty(normalizedUser)) args += $" -u {normalizedUser}";
+            args += " -- sh -c \"cd ~ && pwd\"";
+
+            var psi = new ProcessStartInfo("wsl.exe")
+            {
+                Arguments = args,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+            };
+            using var process = Process.Start(psi);
+            if (process is null) return null;
+
+            var outTask = process.StandardOutput.ReadToEndAsync();
+            var completed = await Task.WhenAny(outTask, Task.Delay(3000));
+            if (completed != outTask) { try { process.Kill(); } catch { } return null; }
+            try { await process.WaitForExitAsync(); } catch { }
+            if (process.ExitCode != 0) return null;
+
+            string home = outTask.Result.Trim();
+            if (string.IsNullOrEmpty(home)) return null;
+            lock (_homeCache) _homeCache[key] = home;
+            return home;
+        }
+        catch (Win32Exception) { return null; }
+        catch (FileNotFoundException) { return null; }
+    }
+
+    private static readonly Dictionary<string, string> _homeCache = new();
+
+    /// <summary>
     /// Converts a WSL distro + Linux-style path to the Windows UNC view of that path
     /// (<c>\\wsl$\Ubuntu\home\alice</c>). Used by GitService and PseudoTerminal's
     /// working-directory argument so Windows-native tools can read the WSL filesystem.

--- a/src/CodeShellManager/Services/WslDiscoveryService.cs
+++ b/src/CodeShellManager/Services/WslDiscoveryService.cs
@@ -94,16 +94,21 @@ public static class WslDiscoveryService
             if (line.TrimStart().StartsWith("NAME", StringComparison.Ordinal)) continue;
 
             var tokens = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            if (tokens.Length < 2) continue;
 
-            bool isDefault = tokens[0] == "*";
-            int idx = isDefault ? 1 : 0;
-            if (tokens.Length - idx < 1) continue;
+            bool isDefault = tokens.Length > 0 && tokens[0] == "*";
+            int firstNameIdx = isDefault ? 1 : 0;
 
-            string name = tokens[idx];
-            string state = tokens.Length - idx >= 2 ? tokens[idx + 1] : "";
-            int version = 0;
-            if (tokens.Length - idx >= 3) int.TryParse(tokens[idx + 2], out version);
+            // `wsl -l -v` always emits three columns: NAME, STATE, VERSION. NAME can
+            // contain spaces if the user `wsl --import`'d a distro with one (rare but
+            // legal), so consume from the end instead of the start: last token is
+            // VERSION, second-to-last is STATE, anything in between is the name.
+            if (tokens.Length - firstNameIdx < 3) continue;
+
+            int versionIdx = tokens.Length - 1;
+            int stateIdx = tokens.Length - 2;
+            string name = string.Join(' ', tokens, firstNameIdx, stateIdx - firstNameIdx);
+            string state = tokens[stateIdx];
+            int.TryParse(tokens[versionIdx], out int version);
 
             results.Add(new WslDistro(name, version, isDefault, state));
         }

--- a/src/CodeShellManager/Services/WslDiscoveryService.cs
+++ b/src/CodeShellManager/Services/WslDiscoveryService.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -67,13 +65,14 @@ public static class WslDiscoveryService
 
             return Parse(outTask.Result);
         }
-        catch (Win32Exception)
+        catch (Exception)
         {
-            // wsl.exe not on PATH — WSL feature isn't installed.
-            return Array.Empty<WslDistro>();
-        }
-        catch (FileNotFoundException)
-        {
+            // Honor the "Never throws" contract: every failure mode (wsl.exe absent,
+            // I/O hiccup, transient process error) collapses to an empty list so the
+            // dialog's Loaded handler never crashes the picker. Specific causes were
+            // previously caught individually (Win32Exception for missing wsl.exe,
+            // FileNotFoundException) but Process.Start + the read pipeline can throw
+            // a wider set than that.
             return Array.Empty<WslDistro>();
         }
     }
@@ -168,8 +167,7 @@ public static class WslDiscoveryService
             lock (_homeCache) _homeCache[key] = home;
             return home;
         }
-        catch (Win32Exception) { return null; }
-        catch (FileNotFoundException) { return null; }
+        catch (Exception) { return null; }
     }
 
     private static readonly Dictionary<string, string> _homeCache = new();

--- a/src/CodeShellManager/Services/WslDiscoveryService.cs
+++ b/src/CodeShellManager/Services/WslDiscoveryService.cs
@@ -151,9 +151,15 @@ public static class WslDiscoveryService
             using var process = Process.Start(psi);
             if (process is null) return null;
 
+            // Drain BOTH stdout and stderr. If we only awaited stdout, a chatty
+            // wsl.exe error (e.g. distro stopped, transient init message) could
+            // fill the stderr pipe buffer and block the child — the stdout await
+            // would never complete and we'd silently fall through to the timeout.
             var outTask = process.StandardOutput.ReadToEndAsync();
-            var completed = await Task.WhenAny(outTask, Task.Delay(3000));
-            if (completed != outTask) { try { process.Kill(); } catch { } return null; }
+            var errTask = process.StandardError.ReadToEndAsync();
+            var bothTask = Task.WhenAll(outTask, errTask);
+            var completed = await Task.WhenAny(bothTask, Task.Delay(3000));
+            if (completed != bothTask) { try { process.Kill(); } catch { } return null; }
             try { await process.WaitForExitAsync(); } catch { }
             if (process.ExitCode != 0) return null;
 

--- a/src/CodeShellManager/Services/WslDiscoveryService.cs
+++ b/src/CodeShellManager/Services/WslDiscoveryService.cs
@@ -138,8 +138,12 @@ public static class WslDiscoveryService
 
         try
         {
-            string args = $"-d {distro}";
-            if (!string.IsNullOrEmpty(normalizedUser)) args += $" -u {normalizedUser}";
+            // QuoteForCmd for parity with the WSL arg builders — distro and user are
+            // usually space-free but Parse now accepts space-containing names, so the
+            // launcher side must not break on the same input.
+            string args = $"-d {Models.ShellSession.QuoteForCmd(distro)}";
+            if (!string.IsNullOrEmpty(normalizedUser))
+                args += $" -u {Models.ShellSession.QuoteForCmd(normalizedUser)}";
             args += " -- sh -c \"cd ~ && pwd\"";
 
             var psi = new ProcessStartInfo("wsl.exe")

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -71,8 +71,9 @@ public partial class SessionViewModel : ObservableObject, IDisposable
     public async Task RefreshGitInfoAsync()
     {
         // SSH sessions have no local working folder to inspect. WSL sessions store
-        // their WorkingFolder as a `\\wsl$\<distro>\...` UNC path, which Git for
-        // Windows handles via `git -C` — so the Local code path applies unchanged.
+        // their WorkingFolder as a `\\wsl$\<distro>\...` UNC; GitService detects that
+        // and dispatches to `wsl.exe -- git -C <linuxPath>` internally (Git for
+        // Windows itself trips on those UNCs — dubious-ownership / .git symlinks).
         if (Session.Kind == SessionKind.Ssh) return;
         var (branch, isDirty) = await GitService.GetGitInfoAsync(Session.WorkingFolder);
         GitBranch = branch;

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -41,31 +41,20 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     public string AccentColor => Session.ColorOverride
         ?? ColorService.GetHexColor(
-            Session.IsRemote
-                ? (string.IsNullOrWhiteSpace(Session.SshUser)
-                    ? Session.SshHost
-                    : $"{Session.SshUser}@{Session.SshHost}")
-                // Key on RepoRoot when known so worktree siblings share a color;
-                // fall back to WorkingFolder for non-git sessions.
-                : (string.IsNullOrEmpty(RepoRoot) ? Session.WorkingFolder : RepoRoot));
+            // SSH never gets a RepoRoot override (no local filesystem); for Local + WSL
+            // prefer RepoRoot so worktree siblings share a color, falling back to
+            // the kind-specific accent key.
+            Session.Kind == SessionKind.Ssh
+                ? Session.AccentKey
+                : (string.IsNullOrEmpty(RepoRoot) ? Session.AccentKey : RepoRoot));
 
     partial void OnRepoRootChanged(string? value) => OnPropertyChanged(nameof(AccentColor));
 
     public string DisplayName => string.IsNullOrWhiteSpace(Session.Name)
-        ? (Session.IsRemote
-            ? (string.IsNullOrWhiteSpace(Session.SshHost) ? Session.Command : Session.SshHost)
-            : System.IO.Path.GetFileName(Session.WorkingFolder.TrimEnd('/', '\\')) ?? Session.Command)
+        ? Session.DefaultDisplayName
         : Session.Name;
 
-    public string FolderShort
-    {
-        get
-        {
-            if (string.IsNullOrEmpty(Session.WorkingFolder)) return "";
-            var di = new System.IO.DirectoryInfo(Session.WorkingFolder);
-            return di.Name;
-        }
-    }
+    public string FolderShort => Session.FolderShort;
 
     public event Action<SessionViewModel>? CloseRequested;
 
@@ -81,7 +70,10 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     public async Task RefreshGitInfoAsync()
     {
-        if (Session.IsRemote) return;
+        // SSH sessions have no local working folder to inspect. WSL sessions store
+        // their WorkingFolder as a `\\wsl$\<distro>\...` UNC path, which Git for
+        // Windows handles via `git -C` — so the Local code path applies unchanged.
+        if (Session.Kind == SessionKind.Ssh) return;
         var (branch, isDirty) = await GitService.GetGitInfoAsync(Session.WorkingFolder);
         GitBranch = branch;
         GitIsDirty = isDirty;

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml
@@ -251,9 +251,18 @@
                          ToolTip="Optional WSL user (-u). Leave blank for the distro's default user."/>
             </Grid>
             <TextBlock Text="Linux Working Folder (optional)" Style="{StaticResource Label}"/>
-            <TextBox x:Name="WslWorkingFolderBox"
-                     AutomationProperties.AutomationId="NewSessionWslWorkingFolderBox"
-                     ToolTip="e.g. /home/alice/project — leave blank for the user's home directory"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="WslWorkingFolderBox"
+                         AutomationProperties.AutomationId="NewSessionWslWorkingFolderBox"
+                         Grid.Column="0" Margin="0,0,6,0"
+                         ToolTip="e.g. /home/alice/project — leave blank for the user's home directory"/>
+                <Button Grid.Column="1" Content="Browse…" Style="{StaticResource Btn}"
+                        Click="BrowseWslFolder_Click"/>
+            </Grid>
             <TextBlock x:Name="WslHelpText"
                        Margin="0,4,0,0"
                        FontSize="11"

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml
@@ -180,6 +180,10 @@
                              AutomationProperties.AutomationId="NewSessionRemoteRadio"
                              Content="Remote (SSH)"
                              Checked="SessionType_Changed"/>
+                <RadioButton x:Name="WslRadio"
+                             AutomationProperties.AutomationId="NewSessionWslRadio"
+                             Content="WSL"
+                             Checked="SessionType_Changed"/>
             </StackPanel>
         </StackPanel>
 
@@ -227,6 +231,35 @@
             <TextBox x:Name="SshRemoteFolderBox"
                      AutomationProperties.AutomationId="NewSessionSshRemoteFolderBox"
                      ToolTip="e.g. /home/alice/project — leave blank for home directory"/>
+        </StackPanel>
+
+        <!-- WSL: distro + linux working folder + optional user -->
+        <StackPanel Grid.Row="3" x:Name="WslPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Distro" Style="{StaticResource Label}"/>
+            <Grid Margin="0,0,0,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="140"/>
+                </Grid.ColumnDefinitions>
+                <ComboBox x:Name="WslDistroCombo"
+                          AutomationProperties.AutomationId="NewSessionWslDistroCombo"
+                          Grid.Column="0" Margin="0,0,6,0"
+                          ToolTip="Installed WSL distros (from `wsl -l -v`)"/>
+                <TextBox x:Name="WslUserBox"
+                         AutomationProperties.AutomationId="NewSessionWslUserBox"
+                         Grid.Column="1"
+                         ToolTip="Optional WSL user (-u). Leave blank for the distro's default user."/>
+            </Grid>
+            <TextBlock Text="Linux Working Folder (optional)" Style="{StaticResource Label}"/>
+            <TextBox x:Name="WslWorkingFolderBox"
+                     AutomationProperties.AutomationId="NewSessionWslWorkingFolderBox"
+                     ToolTip="e.g. /home/alice/project — leave blank for the user's home directory"/>
+            <TextBlock x:Name="WslHelpText"
+                       Margin="0,4,0,0"
+                       FontSize="11"
+                       Foreground="#6c7086"
+                       TextWrapping="Wrap"
+                       Text=""/>
         </StackPanel>
 
         <!-- Command -->

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml
@@ -235,19 +235,26 @@
 
         <!-- WSL: distro + linux working folder + optional user -->
         <StackPanel Grid.Row="3" x:Name="WslPanel" Visibility="Collapsed" Margin="0,0,0,12">
-            <TextBlock Text="Distro" Style="{StaticResource Label}"/>
             <Grid Margin="0,0,0,8">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="140"/>
                 </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBlock Text="Distro" Style="{StaticResource Label}"
+                           Grid.Row="0" Grid.Column="0"/>
+                <TextBlock Text="User (optional)" Style="{StaticResource Label}"
+                           Grid.Row="0" Grid.Column="1" Margin="6,0,0,3"/>
                 <ComboBox x:Name="WslDistroCombo"
                           AutomationProperties.AutomationId="NewSessionWslDistroCombo"
-                          Grid.Column="0" Margin="0,0,6,0"
+                          Grid.Row="1" Grid.Column="0" Margin="0,0,6,0"
                           ToolTip="Installed WSL distros (from `wsl -l -v`)"/>
                 <TextBox x:Name="WslUserBox"
                          AutomationProperties.AutomationId="NewSessionWslUserBox"
-                         Grid.Column="1"
+                         Grid.Row="1" Grid.Column="1"
                          ToolTip="Optional WSL user (-u). Leave blank for the distro's default user."/>
             </Grid>
             <TextBlock Text="Linux Working Folder (optional)" Style="{StaticResource Label}"/>

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -313,15 +313,20 @@ public partial class NewSessionDialog : Window
     /// Linux working-folder box update to match — so they can also switch distros
     /// by drilling into a different one in the dialog.
     /// </summary>
-    private void BrowseWslFolder_Click(object sender, RoutedEventArgs e)
+    private async void BrowseWslFolder_Click(object sender, RoutedEventArgs e)
     {
         string selectedDistro = (WslDistroCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "";
-        string seed = string.IsNullOrEmpty(selectedDistro) ? @"\\wsl$" : $@"\\wsl$\{selectedDistro}";
+        string seed = await ComputeWslBrowseSeedAsync(selectedDistro, WslUserBox.Text.Trim());
 
+        // Both InitialDirectory AND SelectedPath are needed: SelectedPath alone leaves
+        // the COM file dialog rooted at the user's last location (often Documents) for
+        // UNC paths it can't resolve to a shell namespace folder. Setting both makes the
+        // dialog navigate into the WSL share.
         using var dialog = new System.Windows.Forms.FolderBrowserDialog
         {
             Description = "Select Linux working folder (inside WSL)",
             UseDescriptionForTitle = true,
+            InitialDirectory = seed,
             SelectedPath = seed,
         };
         if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
@@ -350,6 +355,20 @@ public partial class NewSessionDialog : Window
             WslWorkingFolderBox.Text = linuxPath;
         }
         AutoFillName();
+    }
+
+    /// <summary>
+    /// Seed path for the WSL folder picker. Prefers the user's home directory inside
+    /// the distro (resolved via <c>cd ~ &amp;&amp; pwd</c>) so picking lands somewhere
+    /// useful; falls back to the distro root when WSL isn't reachable, and to
+    /// <c>\\wsl$</c> when no distro is selected yet.
+    /// </summary>
+    private async System.Threading.Tasks.Task<string> ComputeWslBrowseSeedAsync(string distro, string user)
+    {
+        if (string.IsNullOrEmpty(distro)) return @"\\wsl$";
+        string? home = await WslDiscoveryService.GetDistroHomeAsync(distro, user);
+        if (string.IsNullOrEmpty(home)) return $@"\\wsl$\{distro}";
+        return WslDiscoveryService.ToUncPath(distro, home);
     }
 
     /// <summary>

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -503,7 +503,7 @@ public partial class NewSessionDialog : Window
         ProfileColorSchemeJson = profile.ColorSchemeJson;
     }
 
-    private void Start_Click(object sender, RoutedEventArgs e)
+    private async void Start_Click(object sender, RoutedEventArgs e)
     {
         IsRemote = IsRemoteMode;
         IsWsl = IsWslMode;
@@ -533,6 +533,19 @@ public partial class NewSessionDialog : Window
 
             WslUser = WslUserBox.Text.Trim();
             WslWorkingFolder = WslWorkingFolderBox.Text.Trim();
+
+            // If the user left the Linux folder blank, resolve $HOME eagerly so the
+            // session's WorkingFolder UNC and its Linux path stay in sync. Otherwise
+            // git status runs against the distro root (\\wsl$\<distro> → "/") while
+            // the shell actually starts in $HOME — and the sidebar branch info goes
+            // missing for repos under home. Best-effort: silent fallback to blank
+            // (the existing "land in $HOME, no git info" behavior) when WSL is
+            // unreachable.
+            if (string.IsNullOrEmpty(WslWorkingFolder))
+            {
+                string? home = await WslDiscoveryService.GetDistroHomeAsync(WslDistro, WslUser);
+                if (!string.IsNullOrEmpty(home)) WslWorkingFolder = home;
+            }
 
             var selectedTag = (CommandCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "bash";
             string raw = selectedTag == "custom" ? CustomArgsBox.Text.Trim() : selectedTag;

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -71,6 +71,11 @@ public partial class NewSessionDialog : Window
     /// the user has edited it and we must not stomp.
     /// </summary>
     private string _lastAutoFilledName = "";
+    /// <summary>
+    /// Distro name we want PopulateWslDistrosAsync to pre-select once the combo
+    /// finishes loading. Empty = use the default (first / system default distro).
+    /// </summary>
+    private readonly string _preselectWslDistro = "";
 
     public NewSessionDialog(
         string defaultFolder = "",
@@ -79,11 +84,13 @@ public partial class NewSessionDialog : Window
         string? defaultCommand = null,
         string? defaultArgs = null,
         string? defaultName = null,
-        IReadOnlyList<RecentlyClosedEntry>? recentlyClosed = null)
+        IReadOnlyList<RecentlyClosedEntry>? recentlyClosed = null,
+        ShellSession? defaultSourceSession = null)
     {
         InitializeComponent();
         FolderBox.Text = defaultFolder;
         _profiles = profiles ?? Array.Empty<WindowsTerminalProfile>();
+        _preselectWslDistro = defaultSourceSession?.IsWsl == true ? defaultSourceSession.WslDistro : "";
 
         var customItem = CommandCombo.Items[0];
         CommandCombo.Items.Clear();
@@ -138,6 +145,17 @@ public partial class NewSessionDialog : Window
         WslDistroCombo.SelectionChanged += (_, _) => AutoFillName();
         WslWorkingFolderBox.TextChanged += (_, _) => AutoFillName();
 
+        // Inherit WSL parent: when a user right-clicks a WSL session and picks
+        // "New session here", default the new dialog to WSL mode with the same
+        // distro/user/folder pre-filled. The combo selection happens later in
+        // PopulateWslDistrosAsync (it's async-populated on Loaded).
+        if (defaultSourceSession?.IsWsl == true)
+        {
+            WslRadio.IsChecked = true;
+            WslUserBox.Text = defaultSourceSession.WslUser ?? "";
+            WslWorkingFolderBox.Text = defaultSourceSession.WslWorkingFolder ?? "";
+        }
+
         Loaded += async (_, _) =>
         {
             if (IsLocalMode && !string.IsNullOrWhiteSpace(FolderBox.Text))
@@ -160,12 +178,19 @@ public partial class NewSessionDialog : Window
             WslHelpText.Text = "No WSL distros found. Install WSL from the Microsoft Store, then re-open this dialog.";
             return;
         }
+        ComboBoxItem? preselectMatch = null;
         foreach (var d in distros)
         {
             string label = d.IsDefault ? $"{d.Name}  (default, v{d.Version})" : $"{d.Name}  (v{d.Version})";
-            WslDistroCombo.Items.Add(new ComboBoxItem { Content = label, Tag = d.Name });
+            var item = new ComboBoxItem { Content = label, Tag = d.Name };
+            WslDistroCombo.Items.Add(item);
+            if (!string.IsNullOrEmpty(_preselectWslDistro)
+                && string.Equals(d.Name, _preselectWslDistro, StringComparison.OrdinalIgnoreCase))
+            {
+                preselectMatch = item;
+            }
         }
-        WslDistroCombo.SelectedIndex = 0;
+        WslDistroCombo.SelectedItem = preselectMatch ?? WslDistroCombo.Items[0];
         WslHelpText.Text = "";
     }
 

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -31,6 +31,12 @@ public partial class NewSessionDialog : Window
     public string SshUser { get; private set; } = "";
     public string SshRemoteFolder { get; private set; } = "";
 
+    // WSL session output
+    public bool IsWsl { get; private set; } = false;
+    public string WslDistro { get; private set; } = "";
+    public string WslUser { get; private set; } = "";
+    public string WslWorkingFolder { get; private set; } = "";
+
     // Profile-driven appearance overrides (null when no profile picked)
     public string? ProfileFontFamily { get; private set; }
     public int? ProfileFontSize { get; private set; }
@@ -121,17 +127,43 @@ public partial class NewSessionDialog : Window
 
         FolderBox.TextChanged += (_, _) => { AutoFillName(); ScheduleWorktreeProbe(); };
         SshHostBox.TextChanged += (_, _) => AutoFillName();
+        WslDistroCombo.SelectionChanged += (_, _) => AutoFillName();
+        WslWorkingFolderBox.TextChanged += (_, _) => AutoFillName();
 
         Loaded += async (_, _) =>
         {
-            if (!IsRemoteMode && !string.IsNullOrWhiteSpace(FolderBox.Text))
+            if (IsLocalMode && !string.IsNullOrWhiteSpace(FolderBox.Text))
                 await ProbeSiblingWorktreesAsync(FolderBox.Text.Trim());
+            await PopulateWslDistrosAsync();
         };
+    }
+
+    /// <summary>
+    /// Fills <c>WslDistroCombo</c> from <see cref="WslDiscoveryService.GetDistrosAsync"/>.
+    /// On hosts without WSL installed we leave the combo empty and surface a one-line hint
+    /// so the WSL radio doesn't appear broken.
+    /// </summary>
+    private async System.Threading.Tasks.Task PopulateWslDistrosAsync()
+    {
+        var distros = await WslDiscoveryService.GetDistrosAsync();
+        WslDistroCombo.Items.Clear();
+        if (distros.Count == 0)
+        {
+            WslHelpText.Text = "No WSL distros found. Install WSL from the Microsoft Store, then re-open this dialog.";
+            return;
+        }
+        foreach (var d in distros)
+        {
+            string label = d.IsDefault ? $"{d.Name}  (default, v{d.Version})" : $"{d.Name}  (v{d.Version})";
+            WslDistroCombo.Items.Add(new ComboBoxItem { Content = label, Tag = d.Name });
+        }
+        WslDistroCombo.SelectedIndex = 0;
+        WslHelpText.Text = "";
     }
 
     private void ScheduleWorktreeProbe()
     {
-        if (IsRemoteMode)
+        if (!IsLocalMode)
         {
             WorktreesPanel.Visibility = Visibility.Collapsed;
             return;
@@ -198,6 +230,8 @@ public partial class NewSessionDialog : Window
     }
 
     private bool IsRemoteMode => RemoteRadio?.IsChecked == true;
+    private bool IsWslMode => WslRadio?.IsChecked == true;
+    private bool IsLocalMode => !IsRemoteMode && !IsWslMode;
 
     private void AutoFillName()
     {
@@ -212,6 +246,21 @@ public partial class NewSessionDialog : Window
                 catch { }
             }
         }
+        else if (IsWslMode)
+        {
+            string distro = (WslDistroCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "";
+            string folder = WslWorkingFolderBox.Text.Trim();
+            string leaf = "";
+            if (!string.IsNullOrEmpty(folder))
+            {
+                string trimmed = folder.TrimEnd('/');
+                int slash = trimmed.LastIndexOf('/');
+                leaf = slash >= 0 ? trimmed[(slash + 1)..] : trimmed;
+            }
+            NameBox.Text = string.IsNullOrEmpty(leaf)
+                ? distro
+                : (string.IsNullOrEmpty(distro) ? leaf : $"{distro}: {leaf}");
+        }
         else
         {
             if (!string.IsNullOrWhiteSpace(FolderBox.Text))
@@ -225,17 +274,20 @@ public partial class NewSessionDialog : Window
     private void SessionType_Changed(object sender, RoutedEventArgs e)
     {
         if (LocalPanel == null) return;
-        LocalPanel.Visibility = IsRemoteMode ? Visibility.Collapsed : Visibility.Visible;
+        LocalPanel.Visibility = IsLocalMode ? Visibility.Visible : Visibility.Collapsed;
         SshPanel.Visibility = IsRemoteMode ? Visibility.Visible : Visibility.Collapsed;
+        WslPanel.Visibility = IsWslMode ? Visibility.Visible : Visibility.Collapsed;
         // Profile combobox is local-only
         if (ProfilePanel != null && _profiles.Count > 0)
-            ProfilePanel.Visibility = IsRemoteMode ? Visibility.Collapsed : Visibility.Visible;
+            ProfilePanel.Visibility = IsLocalMode ? Visibility.Visible : Visibility.Collapsed;
         if (WorktreesPanel != null)
         {
             WorktreesPanel.Visibility = Visibility.Collapsed;
             _lastProbedFolder = null;
         }
-        CommandLabel.Text = IsRemoteMode ? "Remote Shell" : "Command";
+        CommandLabel.Text = IsRemoteMode ? "Remote Shell"
+            : IsWslMode ? "Shell (inside WSL)"
+            : "Command";
         NameBox.Text = "";
         AutoFillName();
     }
@@ -321,9 +373,10 @@ public partial class NewSessionDialog : Window
     private void Start_Click(object sender, RoutedEventArgs e)
     {
         IsRemote = IsRemoteMode;
+        IsWsl = IsWslMode;
         SessionName = NameBox.Text.Trim();
 
-        if (!IsRemoteMode && WorktreesPanel.Visibility == Visibility.Visible)
+        if (IsLocalMode && WorktreesPanel.Visibility == Visibility.Visible)
         {
             AdditionalWorktreePaths = WorktreesList.Children.OfType<System.Windows.Controls.CheckBox>()
                 .Where(c => c.IsChecked == true)
@@ -331,6 +384,33 @@ public partial class NewSessionDialog : Window
                 .Where(p => !string.IsNullOrEmpty(p))
                 .Select(p => p!)
                 .ToList();
+        }
+
+        if (IsWsl)
+        {
+            WslDistro = (WslDistroCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "";
+            if (string.IsNullOrWhiteSpace(WslDistro))
+            {
+                System.Windows.MessageBox.Show(
+                    "Please select a WSL distro.",
+                    "Distro required", MessageBoxButton.OK, MessageBoxImage.Warning);
+                WslDistroCombo.Focus();
+                return;
+            }
+
+            WslUser = WslUserBox.Text.Trim();
+            WslWorkingFolder = WslWorkingFolderBox.Text.Trim();
+
+            var selectedTag = (CommandCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "bash";
+            string raw = selectedTag == "custom" ? CustomArgsBox.Text.Trim() : selectedTag;
+            var (exe, args) = CommandLineSplitter.Split(raw);
+            SelectedCommand = string.IsNullOrEmpty(exe) ? "bash" : exe;
+            SelectedArgs = args;
+
+            SelectedFolder = "";
+            DialogResult = true;
+            Close();
+            return;
         }
 
         if (IsRemote)

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -358,16 +358,16 @@ public partial class NewSessionDialog : Window
         string selectedDistro = (WslDistroCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "";
         string seed = await ComputeWslBrowseSeedAsync(selectedDistro, WslUserBox.Text.Trim());
 
-        // Both InitialDirectory AND SelectedPath are needed: SelectedPath alone leaves
-        // the COM file dialog rooted at the user's last location (often Documents) for
-        // UNC paths it can't resolve to a shell namespace folder. Setting both makes the
-        // dialog navigate into the WSL share.
+        // Only InitialDirectory is set: it navigates the dialog to the seed but
+        // leaves the bottom "Folder:" textbox empty (the user is about to pick anyway).
+        // Setting SelectedPath as well shoves the raw UNC into that textbox, which the
+        // shell renders as a truncated, slash-flipped mess (e.g. "bu/home/bitblade") —
+        // worse than empty.
         using var dialog = new System.Windows.Forms.FolderBrowserDialog
         {
             Description = "Select Linux working folder (inside WSL)",
             UseDescriptionForTitle = true,
             InitialDirectory = seed,
-            SelectedPath = seed,
         };
         if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
 

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -307,6 +307,75 @@ public partial class NewSessionDialog : Window
         }
     }
 
+    /// <summary>
+    /// Pops a folder picker rooted at the WSL filesystem (<c>\\wsl$\</c>). When the
+    /// user picks a folder under one of the distros, both the distro combo and the
+    /// Linux working-folder box update to match — so they can also switch distros
+    /// by drilling into a different one in the dialog.
+    /// </summary>
+    private void BrowseWslFolder_Click(object sender, RoutedEventArgs e)
+    {
+        string selectedDistro = (WslDistroCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "";
+        string seed = string.IsNullOrEmpty(selectedDistro) ? @"\\wsl$" : $@"\\wsl$\{selectedDistro}";
+
+        using var dialog = new System.Windows.Forms.FolderBrowserDialog
+        {
+            Description = "Select Linux working folder (inside WSL)",
+            UseDescriptionForTitle = true,
+            SelectedPath = seed,
+        };
+        if (dialog.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
+
+        var (distro, linuxPath) = ParseWslUncPath(dialog.SelectedPath);
+        if (string.IsNullOrEmpty(distro))
+        {
+            // User picked something outside `\\wsl$\<distro>\` — fall back to just
+            // setting the raw path so we don't silently throw away their selection.
+            WslWorkingFolderBox.Text = dialog.SelectedPath;
+        }
+        else
+        {
+            // If they drilled into a different distro than the combo had, switch the combo too.
+            if (!string.Equals(distro, selectedDistro, StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var item in WslDistroCombo.Items.OfType<ComboBoxItem>())
+                {
+                    if (string.Equals(item.Tag as string, distro, StringComparison.OrdinalIgnoreCase))
+                    {
+                        WslDistroCombo.SelectedItem = item;
+                        break;
+                    }
+                }
+            }
+            WslWorkingFolderBox.Text = linuxPath;
+        }
+        AutoFillName();
+    }
+
+    /// <summary>
+    /// Splits a WSL UNC path (<c>\\wsl$\Ubuntu\home\alice</c> or the
+    /// <c>\\wsl.localhost\</c> variant) into (distro, linux-path). Returns empty
+    /// strings when the input isn't a recognizable WSL UNC.
+    /// </summary>
+    internal static (string distro, string linuxPath) ParseWslUncPath(string unc)
+    {
+        if (string.IsNullOrWhiteSpace(unc)) return ("", "");
+        string normalized = unc.Replace('/', '\\').TrimEnd('\\');
+        string[] prefixes = { @"\\wsl$\", @"\\wsl.localhost\" };
+        foreach (var prefix in prefixes)
+        {
+            if (!normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+            string rest = normalized[prefix.Length..];
+            if (string.IsNullOrEmpty(rest)) return ("", "");
+            int slash = rest.IndexOf('\\');
+            string distro = slash < 0 ? rest : rest[..slash];
+            string linuxRest = slash < 0 ? "" : rest[(slash + 1)..];
+            string linuxPath = string.IsNullOrEmpty(linuxRest) ? "" : "/" + linuxRest.Replace('\\', '/');
+            return (distro, linuxPath);
+        }
+        return ("", "");
+    }
+
     private void CommandCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (CustomArgsPanel == null) return;

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -287,13 +287,9 @@ public partial class NewSessionDialog : Window
         {
             string distro = (WslDistroCombo.SelectedItem as ComboBoxItem)?.Tag as string ?? "";
             string folder = WslWorkingFolderBox.Text.Trim();
-            string leaf = "";
-            if (!string.IsNullOrEmpty(folder))
-            {
-                string trimmed = folder.TrimEnd('/');
-                int slash = trimmed.LastIndexOf('/');
-                leaf = slash >= 0 ? trimmed[(slash + 1)..] : trimmed;
-            }
+            string leaf = string.IsNullOrEmpty(folder)
+                ? ""
+                : Path.GetFileName(folder.TrimEnd('/'));
             suggested = string.IsNullOrEmpty(leaf)
                 ? distro
                 : (string.IsNullOrEmpty(distro) ? leaf : $"{distro}: {leaf}");

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -374,9 +374,14 @@ public partial class NewSessionDialog : Window
         var (distro, linuxPath) = ParseWslUncPath(dialog.SelectedPath);
         if (string.IsNullOrEmpty(distro))
         {
-            // User picked something outside `\\wsl$\<distro>\` — fall back to just
-            // setting the raw path so we don't silently throw away their selection.
-            WslWorkingFolderBox.Text = dialog.SelectedPath;
+            // User navigated out of the WSL share entirely (e.g. into C:\…). Putting
+            // a Windows path into the Linux-folder box would just make `wsl --cd`
+            // fail later — so refuse the selection and tell them why.
+            System.Windows.MessageBox.Show(
+                $"'{dialog.SelectedPath}' is not inside a WSL distro.\n\n" +
+                "Please pick a folder under one of the distros shown in the left pane (Linux → Ubuntu, etc.).",
+                "Not a WSL folder", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
         }
         else
         {

--- a/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
+++ b/src/CodeShellManager/Views/NewSessionDialog.xaml.cs
@@ -63,6 +63,14 @@ public partial class NewSessionDialog : Window
     private readonly System.Windows.Threading.DispatcherTimer _worktreeDebounce;
     private System.Threading.CancellationTokenSource? _worktreeProbeCts;
     private string? _lastProbedFolder;
+    /// <summary>
+    /// What we last auto-filled into <see cref="NameBox"/>. AutoFillName uses this
+    /// to tell "the user hasn't typed anything custom" from "the user has". When
+    /// the box equals this value (or is empty), we're free to overwrite it when
+    /// the source context (folder / distro / host) changes. Anything else means
+    /// the user has edited it and we must not stomp.
+    /// </summary>
+    private string _lastAutoFilledName = "";
 
     public NewSessionDialog(
         string defaultFolder = "",
@@ -235,14 +243,18 @@ public partial class NewSessionDialog : Window
 
     private void AutoFillName()
     {
-        if (!string.IsNullOrWhiteSpace(NameBox.Text)) return;
+        // Allow overwrite when the box is empty OR still holds our last auto-fill.
+        // Anything else means the user typed something — leave it alone.
+        if (!string.IsNullOrWhiteSpace(NameBox.Text) && NameBox.Text != _lastAutoFilledName)
+            return;
 
+        string suggested = "";
         if (IsRemoteMode)
         {
             var raw = SshHostBox.Text.Trim();
             if (!string.IsNullOrWhiteSpace(raw))
             {
-                try { NameBox.Text = raw.Split(':')[0]; }
+                try { suggested = raw.Split(':')[0]; }
                 catch { }
             }
         }
@@ -257,7 +269,7 @@ public partial class NewSessionDialog : Window
                 int slash = trimmed.LastIndexOf('/');
                 leaf = slash >= 0 ? trimmed[(slash + 1)..] : trimmed;
             }
-            NameBox.Text = string.IsNullOrEmpty(leaf)
+            suggested = string.IsNullOrEmpty(leaf)
                 ? distro
                 : (string.IsNullOrEmpty(distro) ? leaf : $"{distro}: {leaf}");
         }
@@ -265,10 +277,13 @@ public partial class NewSessionDialog : Window
         {
             if (!string.IsNullOrWhiteSpace(FolderBox.Text))
             {
-                try { NameBox.Text = Path.GetFileName(FolderBox.Text.TrimEnd('/', '\\')); }
+                try { suggested = Path.GetFileName(FolderBox.Text.TrimEnd('/', '\\')) ?? ""; }
                 catch { }
             }
         }
+
+        NameBox.Text = suggested;
+        _lastAutoFilledName = suggested;
     }
 
     private void SessionType_Changed(object sender, RoutedEventArgs e)

--- a/tests/CodeShellManager.Tests/GitServiceWslRoutingTests.cs
+++ b/tests/CodeShellManager.Tests/GitServiceWslRoutingTests.cs
@@ -1,0 +1,88 @@
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// Headless coverage for the WSL routing helpers in GitService. The live
+/// wsl.exe dispatch can't run on every test host; these cover the path/arg
+/// translation that has to be exactly right for routing to land in the
+/// correct place.
+/// </summary>
+public class GitServiceWslRoutingTests
+{
+    [Theory]
+    [InlineData(@"\\wsl$\Ubuntu\home\alice", "Ubuntu", "/home/alice")]
+    [InlineData(@"\\wsl.localhost\Debian\srv\app", "Debian", "/srv/app")]
+    [InlineData(@"\\wsl$\Ubuntu", "Ubuntu", "/")]
+    [InlineData(@"C:\proj", null, "")]
+    [InlineData("", null, "")]
+    public void TryParseWslUnc_KnownShapes(string path, string? expectedDistro, string expectedLinux)
+    {
+        var (distro, linuxPath) = GitService.TryParseWslUnc(path);
+        Assert.Equal(expectedDistro, distro);
+        Assert.Equal(expectedLinux, linuxPath);
+    }
+
+    [Fact]
+    public void TranslateUncArgsToLinux_MatchingDistro_Substitutes()
+    {
+        string args = "worktree add \"\\\\wsl$\\Ubuntu\\home\\alice\\proj-foo\" main";
+        string translated = GitService.TranslateUncArgsToLinux(args, "Ubuntu");
+        Assert.Contains("/home/alice/proj-foo", translated);
+        Assert.DoesNotContain(@"\\wsl$\Ubuntu", translated);
+    }
+
+    [Fact]
+    public void TranslateUncArgsToLinux_DifferentDistro_LeftAlone()
+    {
+        // We're running git inside Ubuntu — a UNC pointing at Debian is a real
+        // mistake and should NOT be silently rewritten to look like a local path.
+        string args = @"worktree add \\wsl$\Debian\home\alice\proj main";
+        string translated = GitService.TranslateUncArgsToLinux(args, "Ubuntu");
+        Assert.Equal(args, translated);
+    }
+
+    [Fact]
+    public void TranslateUncArgsToLinux_NoUncs_Passthrough()
+    {
+        string args = "branch --show-current";
+        Assert.Equal(args, GitService.TranslateUncArgsToLinux(args, "Ubuntu"));
+    }
+
+    [Fact]
+    public void TranslateLinuxPathsToUnc_RevParseOutput()
+    {
+        string raw = "/home/alice/proj/.git\n";
+        string translated = GitService.TranslateLinuxPathsToUnc(raw, "Ubuntu");
+        Assert.Contains(@"\\wsl$\Ubuntu\home\alice\proj\.git", translated);
+    }
+
+    [Fact]
+    public void TranslateLinuxPathsToUnc_WorktreeListPorcelain()
+    {
+        // Real-ish output: only the `worktree /…` lines carry abs paths; the rest
+        // (HEAD sha, refs/heads/x) must NOT be mangled.
+        string raw = "worktree /home/alice/proj\nHEAD abc123\nbranch refs/heads/main\n";
+        string translated = GitService.TranslateLinuxPathsToUnc(raw, "Ubuntu");
+        Assert.Contains(@"worktree \\wsl$\Ubuntu\home\alice\proj", translated);
+        Assert.Contains("HEAD abc123", translated);
+        Assert.Contains("branch refs/heads/main", translated);
+    }
+
+    [Fact]
+    public void TranslateLinuxPathsToUnc_BranchNameWithSlash_NotMangled()
+    {
+        // refs/heads/feature/foo starts with 'r', not '/' — must pass through.
+        string raw = "feature/wsl-sessions\n";
+        Assert.Equal(raw, GitService.TranslateLinuxPathsToUnc(raw, "Ubuntu"));
+    }
+
+    [Fact]
+    public void TranslateLinuxPathsToUnc_StatusPorcelain_Untouched()
+    {
+        // Each "M file" / "?? new" line has no leading slash and shouldn't change.
+        string raw = "M README.md\n?? new.txt\n";
+        Assert.Equal(raw, GitService.TranslateLinuxPathsToUnc(raw, "Ubuntu"));
+    }
+}

--- a/tests/CodeShellManager.Tests/GitServiceWslRoutingTests.cs
+++ b/tests/CodeShellManager.Tests/GitServiceWslRoutingTests.cs
@@ -104,4 +104,15 @@ public class GitServiceWslRoutingTests
         string translated = GitService.TranslateUncArgsToLinux(args, "Ubuntu");
         Assert.Equal("rev-parse \"/\"", translated);
     }
+
+    [Fact]
+    public void TranslateLinuxPathsToUnc_PathContainsSpaces_TranslatesWholePath()
+    {
+        // Regression: the tail used to stop at the first whitespace, so a worktree
+        // path with a space got half-translated.
+        string raw = "worktree /home/alice/My Projects/repo\n";
+        string translated = GitService.TranslateLinuxPathsToUnc(raw, "Ubuntu");
+        Assert.Contains(@"\\wsl$\Ubuntu\home\alice\My Projects\repo", translated);
+        Assert.DoesNotContain("Projects/repo", translated); // no leftover forward slashes
+    }
 }

--- a/tests/CodeShellManager.Tests/GitServiceWslRoutingTests.cs
+++ b/tests/CodeShellManager.Tests/GitServiceWslRoutingTests.cs
@@ -85,4 +85,23 @@ public class GitServiceWslRoutingTests
         string raw = "M README.md\n?? new.txt\n";
         Assert.Equal(raw, GitService.TranslateLinuxPathsToUnc(raw, "Ubuntu"));
     }
+
+    [Fact]
+    public void TranslateUncArgsToLinux_QuotedUncWithSpaces_TranslatedWholeAndReQuoted()
+    {
+        // Regression: the unquoted regex stops at whitespace, so a quoted UNC
+        // containing a space (worktree add target) used to be half-translated.
+        string args = "worktree add \"\\\\wsl$\\Ubuntu\\home\\alice\\my repo\" main";
+        string translated = GitService.TranslateUncArgsToLinux(args, "Ubuntu");
+        Assert.Contains("\"/home/alice/my repo\"", translated);
+        Assert.DoesNotContain(@"\\wsl$\Ubuntu", translated);
+    }
+
+    [Fact]
+    public void TranslateUncArgsToLinux_QuotedUncRoot_BecomesQuotedRoot()
+    {
+        string args = "rev-parse \"\\\\wsl$\\Ubuntu\"";
+        string translated = GitService.TranslateUncArgsToLinux(args, "Ubuntu");
+        Assert.Equal("rev-parse \"/\"", translated);
+    }
 }

--- a/tests/CodeShellManager.Tests/NewSessionDialogTests.cs
+++ b/tests/CodeShellManager.Tests/NewSessionDialogTests.cs
@@ -1,0 +1,33 @@
+using CodeShellManager.Views;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// Headless coverage for the bits of <see cref="NewSessionDialog"/> that don't
+/// require a window (parsing helpers). UI-level behavior lives in UITests.
+/// </summary>
+public class NewSessionDialogTests
+{
+    [Theory]
+    [InlineData(@"\\wsl$\Ubuntu\home\alice\proj", "Ubuntu", "/home/alice/proj")]
+    [InlineData(@"\\wsl.localhost\Debian\srv\app", "Debian", "/srv/app")]
+    [InlineData(@"\\wsl$\Ubuntu", "Ubuntu", "")]
+    [InlineData(@"\\wsl$\Ubuntu\", "Ubuntu", "")]
+    [InlineData(@"C:\proj", "", "")]
+    [InlineData("", "", "")]
+    public void ParseWslUncPath_KnownShapes(string unc, string expectedDistro, string expectedLinux)
+    {
+        var (distro, linuxPath) = NewSessionDialog.ParseWslUncPath(unc);
+        Assert.Equal(expectedDistro, distro);
+        Assert.Equal(expectedLinux, linuxPath);
+    }
+
+    [Fact]
+    public void ParseWslUncPath_ForwardSlashes_Normalized()
+    {
+        var (distro, linuxPath) = NewSessionDialog.ParseWslUncPath(@"//wsl$/Ubuntu/home/alice");
+        Assert.Equal("Ubuntu", distro);
+        Assert.Equal("/home/alice", linuxPath);
+    }
+}

--- a/tests/CodeShellManager.Tests/RunInstanceTests.cs
+++ b/tests/CodeShellManager.Tests/RunInstanceTests.cs
@@ -89,7 +89,9 @@ public class RunInstanceTests
             WslWorkingFolder = "/home/alice/proj",
         };
         string args = RunInstance.BuildWslArgs(p, "cargo test");
-        Assert.Equal("-d Ubuntu -u alice --cd /home/alice/proj -- bash -lc 'cargo test'", args);
+        // Double quotes (Windows-side grouping) — single quotes would leak through
+        // Windows command-line tokenization and reach bash as broken token pieces.
+        Assert.Equal("-d Ubuntu -u alice --cd /home/alice/proj -- bash -lc \"cargo test\"", args);
     }
 
     [Fact]
@@ -97,14 +99,27 @@ public class RunInstanceTests
     {
         var p = new ShellSession { Kind = SessionKind.Wsl, WslDistro = "Debian" };
         string args = RunInstance.BuildWslArgs(p, "ls");
-        Assert.Equal("-d Debian -- bash -lc 'ls'", args);
+        Assert.Equal("-d Debian -- bash -lc \"ls\"", args);
     }
 
     [Fact]
-    public void BuildWslArgs_CommandLineWithApostrophe_IsEscaped()
+    public void BuildWslArgs_CommandLineWithEmbeddedDoubleQuote_Escapes()
     {
         var p = new ShellSession { Kind = SessionKind.Wsl, WslDistro = "Ubuntu" };
+        string args = RunInstance.BuildWslArgs(p, "echo \"hi\"");
+        Assert.Contains("bash -lc \"echo \\\"hi\\\"\"", args);
+    }
+
+    [Fact]
+    public void BuildWslArgs_CommandLineWithApostrophe_PassesThroughVerbatim()
+    {
+        // Apostrophes need no escaping from us — the outer wrapper is "..." so
+        // Windows tokenization keeps the whole commandLine as one argv entry, and
+        // bash then sees the apostrophe at face value. (What bash does with an
+        // unbalanced apostrophe is the caller's problem; we just refuse to mangle
+        // it during arg-building.)
+        var p = new ShellSession { Kind = SessionKind.Wsl, WslDistro = "Ubuntu" };
         string args = RunInstance.BuildWslArgs(p, "echo it's me");
-        Assert.Contains(@"bash -lc 'echo it'\''s me'", args);
+        Assert.Contains("bash -lc \"echo it's me\"", args);
     }
 }

--- a/tests/CodeShellManager.Tests/RunInstanceTests.cs
+++ b/tests/CodeShellManager.Tests/RunInstanceTests.cs
@@ -79,4 +79,32 @@ public class RunInstanceTests
         string decoded = System.Text.Encoding.Unicode.GetString(System.Convert.FromBase64String(b64));
         Assert.Equal(cmd, decoded);
     }
+
+    [Fact]
+    public void BuildWslArgs_HappyPath_BuildsExpectedShape()
+    {
+        var p = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu", WslUser = "alice",
+            WslWorkingFolder = "/home/alice/proj",
+        };
+        string args = RunInstance.BuildWslArgs(p, "cargo test");
+        Assert.Equal("-d Ubuntu -u alice --cd /home/alice/proj -- bash -lc 'cargo test'", args);
+    }
+
+    [Fact]
+    public void BuildWslArgs_NoUserOrFolder_OmitsFlags()
+    {
+        var p = new ShellSession { Kind = SessionKind.Wsl, WslDistro = "Debian" };
+        string args = RunInstance.BuildWslArgs(p, "ls");
+        Assert.Equal("-d Debian -- bash -lc 'ls'", args);
+    }
+
+    [Fact]
+    public void BuildWslArgs_CommandLineWithApostrophe_IsEscaped()
+    {
+        var p = new ShellSession { Kind = SessionKind.Wsl, WslDistro = "Ubuntu" };
+        string args = RunInstance.BuildWslArgs(p, "echo it's me");
+        Assert.Contains(@"bash -lc 'echo it'\''s me'", args);
+    }
 }

--- a/tests/CodeShellManager.Tests/ShellSessionMigrationTests.cs
+++ b/tests/CodeShellManager.Tests/ShellSessionMigrationTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using CodeShellManager.Models;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// State-file migration coverage. Legacy state.json predates the <see cref="SessionKind"/>
+/// enum and only carried <c>IsRemote</c>; the deserializer must still produce a session
+/// with the right <see cref="ShellSession.Kind"/>.
+/// </summary>
+public class ShellSessionMigrationTests
+{
+    [Fact]
+    public void Deserialize_LegacyIsRemoteTrue_PromotesKindToSsh()
+    {
+        // Hand-rolled to match what an older app version would have written —
+        // no `Kind` key, only `IsRemote`.
+        const string legacy = """
+            {
+              "IsRemote": true,
+              "SshUser": "alice",
+              "SshHost": "dev.example.com",
+              "SshPort": 22
+            }
+            """;
+        var s = JsonSerializer.Deserialize<ShellSession>(legacy)!;
+        Assert.Equal(SessionKind.Ssh, s.Kind);
+        Assert.True(s.IsRemote);
+        Assert.Equal("alice", s.SshUser);
+    }
+
+    [Fact]
+    public void Deserialize_LegacyIsRemoteFalse_KeepsKindLocal()
+    {
+        const string legacy = """{ "IsRemote": false, "WorkingFolder": "C:\\proj" }""";
+        var s = JsonSerializer.Deserialize<ShellSession>(legacy)!;
+        Assert.Equal(SessionKind.Local, s.Kind);
+        Assert.False(s.IsRemote);
+    }
+
+    [Fact]
+    public void Deserialize_NewFormatWithKindWsl_LeavesIsRemoteFalse()
+    {
+        // StateService doesn't configure JsonStringEnumConverter, so enums round-trip
+        // as integers. SessionKind.Wsl == 2.
+        const string current = """
+            {
+              "Kind": 2,
+              "WslDistro": "Ubuntu",
+              "WslWorkingFolder": "/home/alice/proj"
+            }
+            """;
+        var s = JsonSerializer.Deserialize<ShellSession>(current)!;
+        Assert.Equal(SessionKind.Wsl, s.Kind);
+        Assert.False(s.IsRemote);
+        Assert.Equal("Ubuntu", s.WslDistro);
+    }
+
+    [Fact]
+    public void Deserialize_BothKindAndLegacyIsRemote_KindWinsWhenKindIsWsl()
+    {
+        // Defensive: a file written by new code carries both IsRemote (computed, so false
+        // for Wsl) and Kind. Verify the setter never demotes a Wsl Kind back to Ssh.
+        const string mixed = """
+            {
+              "Kind": 2,
+              "IsRemote": false,
+              "WslDistro": "Ubuntu"
+            }
+            """;
+        var s = JsonSerializer.Deserialize<ShellSession>(mixed)!;
+        Assert.Equal(SessionKind.Wsl, s.Kind);
+    }
+
+    [Fact]
+    public void Roundtrip_NewFormat_PreservesKind()
+    {
+        var original = new ShellSession
+        {
+            Kind = SessionKind.Wsl,
+            WslDistro = "Debian",
+            WslUser = "bob",
+            WslWorkingFolder = "/srv/app",
+        };
+        string json = JsonSerializer.Serialize(original);
+        var revived = JsonSerializer.Deserialize<ShellSession>(json)!;
+        Assert.Equal(SessionKind.Wsl, revived.Kind);
+        Assert.Equal("Debian", revived.WslDistro);
+        Assert.Equal("bob", revived.WslUser);
+        Assert.Equal("/srv/app", revived.WslWorkingFolder);
+    }
+}

--- a/tests/CodeShellManager.Tests/ShellSessionTests.cs
+++ b/tests/CodeShellManager.Tests/ShellSessionTests.cs
@@ -90,4 +90,104 @@ public class ShellSessionTests
         };
         Assert.Throws<InvalidOperationException>(() => s.BuildSshArgs());
     }
+
+    [Fact]
+    public void IsRemote_SetTrue_PromotesKindToSsh()
+    {
+        var s = new ShellSession { IsRemote = true };
+        Assert.Equal(SessionKind.Ssh, s.Kind);
+        Assert.True(s.IsRemote);
+    }
+
+    [Fact]
+    public void IsRemote_GetterTrueOnlyForSsh()
+    {
+        Assert.False(new ShellSession { Kind = SessionKind.Local }.IsRemote);
+        Assert.True(new ShellSession { Kind = SessionKind.Ssh }.IsRemote);
+        Assert.False(new ShellSession { Kind = SessionKind.Wsl }.IsRemote);
+    }
+
+    [Fact]
+    public void BuildWslArgs_HappyPath_BuildsExpectedShape()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu", WslUser = "alice",
+            WslWorkingFolder = "/home/alice/proj", Command = "claude",
+        };
+        Assert.Equal("-d Ubuntu -u alice --cd /home/alice/proj -- bash -lc \"claude\"",
+            s.BuildWslArgs());
+    }
+
+    [Fact]
+    public void BuildWslArgs_NoUser_OmitsUserFlag()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Debian",
+            WslWorkingFolder = "/srv", Command = "bash",
+        };
+        Assert.Equal("-d Debian --cd /srv -- bash -lc \"bash\"", s.BuildWslArgs());
+    }
+
+    [Fact]
+    public void BuildWslArgs_NoWorkingFolder_OmitsCdFlag()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu", Command = "bash",
+        };
+        Assert.Equal("-d Ubuntu -- bash -lc \"bash\"", s.BuildWslArgs());
+    }
+
+    [Fact]
+    public void BuildWslArgs_ArgsAppendedToShell()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu",
+            Command = "claude", Args = "--continue",
+        };
+        Assert.Contains("bash -lc \"claude --continue\"", s.BuildWslArgs());
+    }
+
+    [Fact]
+    public void BuildWslArgs_EmptyDistro_ThrowsInvalidOperationException()
+    {
+        var s = new ShellSession { Kind = SessionKind.Wsl, WslDistro = "", Command = "bash" };
+        Assert.Throws<InvalidOperationException>(() => s.BuildWslArgs());
+    }
+
+    [Fact]
+    public void FullCommandLine_Wsl_StartsWithWslExe()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu",
+            Command = "claude",
+        };
+        Assert.StartsWith("wsl.exe ", s.FullCommandLine);
+    }
+
+    [Fact]
+    public void DefaultDisplayName_WslWithFolder_IsDistroAndLeaf()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu",
+            WslWorkingFolder = "/home/alice/proj",
+        };
+        Assert.Equal("Ubuntu: proj", s.DefaultDisplayName);
+    }
+
+    [Fact]
+    public void AccentKey_Wsl_DistinctFromLocal()
+    {
+        var wsl = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu", WslWorkingFolder = "/proj",
+        };
+        var local = new ShellSession { WorkingFolder = "/proj" };
+        Assert.NotEqual(wsl.AccentKey, local.AccentKey);
+    }
 }

--- a/tests/CodeShellManager.Tests/ShellSessionTests.cs
+++ b/tests/CodeShellManager.Tests/ShellSessionTests.cs
@@ -190,4 +190,27 @@ public class ShellSessionTests
         var local = new ShellSession { WorkingFolder = "/proj" };
         Assert.NotEqual(wsl.AccentKey, local.AccentKey);
     }
+
+    [Theory]
+    [InlineData("Ubuntu", "Ubuntu")]
+    [InlineData("", "\"\"")]
+    [InlineData("/home/alice/proj", "/home/alice/proj")]
+    [InlineData("/home/alice/my proj", "\"/home/alice/my proj\"")]
+    [InlineData("with\"quote", "\"with\\\"quote\"")]
+    public void QuoteForCmd_QuotesWhenNeeded(string input, string expected)
+    {
+        Assert.Equal(expected, ShellSession.QuoteForCmd(input));
+    }
+
+    [Fact]
+    public void BuildWslArgs_LinuxPathWithSpaces_QuotesCdValue()
+    {
+        var s = new ShellSession
+        {
+            Kind = SessionKind.Wsl, WslDistro = "Ubuntu",
+            WslWorkingFolder = "/home/alice/my proj", Command = "claude",
+        };
+        Assert.Equal("-d Ubuntu --cd \"/home/alice/my proj\" -- bash -lc \"claude\"",
+            s.BuildWslArgs());
+    }
 }

--- a/tests/CodeShellManager.Tests/WslDiscoveryServiceTests.cs
+++ b/tests/CodeShellManager.Tests/WslDiscoveryServiceTests.cs
@@ -82,4 +82,21 @@ public class WslDiscoveryServiceTests
     {
         Assert.Equal("", WslDiscoveryService.ToUncPath("", "/home/x"));
     }
+
+    [Fact]
+    public void Parse_DistroNameWithSpace_ParsesNameCorrectly()
+    {
+        // `wsl --import "My Distro" ...` produces a row where NAME spans two tokens.
+        // Old parser took just the first token; the from-the-end approach takes
+        // the trailing two columns as STATE/VERSION and joins the rest as NAME.
+        const string raw =
+            "  NAME             STATE           VERSION\n" +
+            "* My Distro        Running         2\n";
+        var result = WslDiscoveryService.Parse(raw);
+        Assert.Single(result);
+        Assert.Equal("My Distro", result[0].Name);
+        Assert.Equal("Running", result[0].State);
+        Assert.Equal(2, result[0].Version);
+        Assert.True(result[0].IsDefault);
+    }
 }

--- a/tests/CodeShellManager.Tests/WslDiscoveryServiceTests.cs
+++ b/tests/CodeShellManager.Tests/WslDiscoveryServiceTests.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+public class WslDiscoveryServiceTests
+{
+    // Sample copied from `wsl -l -v` on a host with two distros installed. The
+    // leading whitespace in front of "NAME" and the spacing are intentional —
+    // wsl pads columns with spaces, never tabs.
+    private const string SampleOutput =
+        "  NAME                   STATE           VERSION\n" +
+        "* Ubuntu                 Running         2\n" +
+        "  Debian                 Stopped         2\n";
+
+    [Fact]
+    public void Parse_TwoDistros_ReturnsBoth()
+    {
+        var result = WslDiscoveryService.Parse(SampleOutput);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void Parse_MarksDefaultDistro()
+    {
+        var result = WslDiscoveryService.Parse(SampleOutput);
+        Assert.Single(result, d => d.IsDefault);
+        Assert.Equal("Ubuntu", result[0].Name); // default sorted first
+    }
+
+    [Fact]
+    public void Parse_ParsesVersionAndState()
+    {
+        var result = WslDiscoveryService.Parse(SampleOutput);
+        var ubuntu = result.Single(d => d.Name == "Ubuntu");
+        Assert.Equal(2, ubuntu.Version);
+        Assert.Equal("Running", ubuntu.State);
+    }
+
+    [Fact]
+    public void Parse_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Empty(WslDiscoveryService.Parse(""));
+        Assert.Empty(WslDiscoveryService.Parse("   \n"));
+    }
+
+    [Fact]
+    public void Parse_HeaderOnly_ReturnsEmpty()
+    {
+        Assert.Empty(WslDiscoveryService.Parse("  NAME                   STATE           VERSION\n"));
+    }
+
+    [Fact]
+    public void Parse_NonDefaultThenDefault_OrdersDefaultFirst()
+    {
+        const string reversed =
+            "  NAME       STATE           VERSION\n" +
+            "  Debian     Stopped         2\n" +
+            "* Ubuntu     Running         2\n";
+        var result = WslDiscoveryService.Parse(reversed);
+        Assert.Equal("Ubuntu", result[0].Name);
+        Assert.True(result[0].IsDefault);
+    }
+
+    [Fact]
+    public void ToUncPath_HappyPath()
+    {
+        Assert.Equal(@"\\wsl$\Ubuntu\home\alice\proj",
+            WslDiscoveryService.ToUncPath("Ubuntu", "/home/alice/proj"));
+    }
+
+    [Fact]
+    public void ToUncPath_NoLinuxPath_ReturnsDistroRoot()
+    {
+        Assert.Equal(@"\\wsl$\Ubuntu",
+            WslDiscoveryService.ToUncPath("Ubuntu", ""));
+    }
+
+    [Fact]
+    public void ToUncPath_NoDistro_ReturnsEmpty()
+    {
+        Assert.Equal("", WslDiscoveryService.ToUncPath("", "/home/x"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds **WSL** as a third session kind alongside Local and SSH. The New Session
dialog gains a `WSL` radio that auto-detects installed distros via `wsl -l -v`,
lets the user pick a Linux working folder (with a Browse button rooted at
`\\wsl$\<distro>\~`), and optionally pins a `-u <user>`. The session is then
launched via `wsl.exe -d <distro> [-u <user>] --cd <linux-path> -- bash -lc '<cmd>'`,
so anything you can normally run inside the distro — `claude`, `codex`, `gh
copilot`, plain bash — Just Works.

Git status, repo-root detection, sibling-worktree listing, and `git worktree
add` all work for WSL sessions: GitService transparently dispatches to
`wsl.exe -d <distro> -- git -C <linuxPath> …` when the working folder is a
`\\wsl$\` UNC, translating arg-side and stdout-side paths so the rest of the
app keeps seeing Windows-shaped paths.

## Why

WSL is increasingly where Claude Code and other agent CLIs live for Windows
users (Linux toolchain, native filesystem speed, easier shell environments).
Before this PR the only way to drive WSL through CodeShellManager was to add
`wsl.exe` as a custom launch command — no distro picker, no working-folder
field, no git status, no Open in Explorer / right-click → New worktree, no
sleep/wake of a distinct-distro session, etc.

## Implementation notes

- **`SessionKind` enum** on `ShellSession`: `Local | Ssh | Wsl`. The legacy
  `IsRemote` bool stays as a back-compat shim — its setter promotes
  `Local → Ssh` so old `state.json` files that only carried `\"IsRemote\": true`
  migrate cleanly without any custom converter. `IsWsl` added for symmetry.
- **WSL sessions store WorkingFolder as a `\\wsl$\<distro>\…` UNC** so things
  that touch a Windows-shaped path (Explorer, the dormant sidebar item, the
  active-pane subtitle) need no special-casing. The Linux-side path lives on
  `WslWorkingFolder` and is what gets passed to `wsl.exe --cd`.
- **GitService routing** detects the WSL UNC in its single `RunGitFullAsync`
  funnel — every higher-level method (status, branch, rev-parse, worktree
  list/add) inherits the routing for free. Two translators handle path
  shape:
  - `TranslateUncArgsToLinux`: \\\\wsl\$\\\<distro\>\\foo → /foo in arg strings,
    only when the distro matches (other-distro UNCs pass through unchanged).
  - `TranslateLinuxPathsToUnc`: absolute Linux paths in stdout → UNC, with a
    conservative regex that only fires at word boundaries so things like
    `refs/heads/main` aren't mangled.
- **InheritSessionKindFrom** consolidates the \"clone a session derived from a
  parent\" logic used by Duplicate, sibling-worktree, and the new-worktree
  dialog — previously three near-identical inline copies that would have
  drifted as soon as a fourth kind landed.

## Test plan

- [x] **New WSL session**: ＋ → WSL → pick distro → Browse opens at
      `\\wsl$\<distro>\<home>` → pick a subfolder → Start. Confirm prompt
      lands inside WSL (`whoami`/`pwd` look correct).
- [x] **Git status**: open a WSL session pointed at a repo. Sidebar should
      show the branch and dirty state. Run `git status` inside the session
      and the dirty dot should match.
- [x] **Distro picker / user**: switch distros in the combo — name suggestion
      updates. Type a `-u` user — picker re-seeds at that user's home.
- [x] **Right-click on a WSL session → New session here**: dialog should open
      in WSL mode pre-filled with the parent's distro/user/folder, not Local
      mode with the UNC.
- [x] **Right-click → Open WSL console here**: spawns a bare bash session
      inside the same distro+folder.
- [x] **Right-click → New worktree from this branch**: dialog opens (no
      \"not a git repo\"), worktree is created via `wsl.exe -- git worktree
      add`, the new session opens as WSL (not PS at the UNC) and runs the
      parent's command (claude/etc.) successfully.
- [x] **Sleep/wake** a WSL session: should persist distro/user/folder through
      state.json and relaunch identically.
- [x] **Legacy state.json migration**: load an old state.json with
      `\"IsRemote\": true` SSH sessions — should still deserialize as SSH
      (covered by `ShellSessionMigrationTests`).
- [ ] **WSL-less host**: WSL radio still appears; the distro combo is empty
      with an inline \"No WSL distros found…\" hint.
- [x] **252 unit tests pass** locally.

## Screenshots

_(I can add screenshots of the WSL panel + browse picker if helpful — happy
to follow up.)_