### PR TITLE
fix(claude): honor CLAUDE_CONFIG_DIR when resolving the resume session id

### DIFF
--- a/src/CodeShellManager/Services/ClaudeSessionService.cs
+++ b/src/CodeShellManager/Services/ClaudeSessionService.cs
@@ -19,19 +19,36 @@ public static class ClaudeSessionService
         command.StartsWith("claude ", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Resolves the directory Claude Code keeps its data in. CLAUDE_CONFIG_DIR wins when
+    /// set; otherwise the default ~/.claude.
+    ///
+    /// This matters because a machine that has ever run without the env var keeps a stale
+    /// ~/.claude/projects/ tree. Reading that one yields a session id from the wrong store
+    /// and `claude --resume &lt;id&gt;` fails with "No conversation found with session ID".
+    /// </summary>
+    internal static string ResolveClaudeHome(string? configDir, string userProfile) =>
+        string.IsNullOrWhiteSpace(configDir)
+            ? Path.Combine(userProfile, ".claude")
+            : configDir;
+
+    /// <summary>
     /// Finds the most recently modified session ID for the given working folder.
     /// Returns null if no session exists (new project or claude not yet run there).
     /// </summary>
-    public static string? GetLastSessionId(string workingFolder)
+    public static string? GetLastSessionId(string workingFolder) =>
+        GetLastSessionId(workingFolder, ResolveClaudeHome(
+            Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR"),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)));
+
+    /// <param name="claudeHome">Claude's data directory — see <see cref="ResolveClaudeHome"/>.</param>
+    internal static string? GetLastSessionId(string workingFolder, string claudeHome)
     {
         if (string.IsNullOrWhiteSpace(workingFolder)) return null;
 
         try
         {
             string projectDir = ToProjectDirName(workingFolder);
-            string claudeProjectsPath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                ".claude", "projects", projectDir);
+            string claudeProjectsPath = Path.Combine(claudeHome, "projects", projectDir);
 
             if (!Directory.Exists(claudeProjectsPath)) return null;
 

--- a/tests/CodeShellManager.Tests/ClaudeSessionServiceTests.cs
+++ b/tests/CodeShellManager.Tests/ClaudeSessionServiceTests.cs
@@ -1,0 +1,145 @@
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// Claude Code stores conversations under CLAUDE_CONFIG_DIR when that env var is set,
+/// falling back to ~/.claude. Reading the wrong root yields a session id from a stale
+/// store, and `claude --resume &lt;id&gt;` then fails with "No conversation found with
+/// session ID". Timestamps are set explicitly rather than via Task.Delay — Windows'
+/// ~15.6ms timer granularity makes wall-clock ordering flaky.
+/// </summary>
+public class ClaudeSessionServiceTests : IDisposable
+{
+    private readonly string _root;
+
+    public ClaudeSessionServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "csm-claude-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>Creates &lt;claudeHome&gt;/projects/&lt;dirName&gt; and returns it.</summary>
+    private string MakeProjectDir(string claudeHome, string dirName)
+    {
+        string p = Path.Combine(claudeHome, "projects", dirName);
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    private static void WriteSession(string projectDir, string sessionId, DateTime lastWriteUtc)
+    {
+        string f = Path.Combine(projectDir, sessionId + ".jsonl");
+        File.WriteAllText(f, "{}\n");
+        File.SetLastWriteTimeUtc(f, lastWriteUtc);
+    }
+
+    // ── ResolveClaudeHome ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveClaudeHome_UsesConfigDir_WhenSet()
+    {
+        string result = ClaudeSessionService.ResolveClaudeHome(
+            @"C:\Users\someone\.claude-work", @"C:\Users\someone");
+
+        Assert.Equal(@"C:\Users\someone\.claude-work", result);
+    }
+
+    [Fact]
+    public void ResolveClaudeHome_FallsBackToDotClaude_WhenConfigDirNull()
+    {
+        string result = ClaudeSessionService.ResolveClaudeHome(null, @"C:\Users\someone");
+
+        Assert.Equal(Path.Combine(@"C:\Users\someone", ".claude"), result);
+    }
+
+    [Fact]
+    public void ResolveClaudeHome_FallsBackToDotClaude_WhenConfigDirBlank()
+    {
+        string result = ClaudeSessionService.ResolveClaudeHome("   ", @"C:\Users\someone");
+
+        Assert.Equal(Path.Combine(@"C:\Users\someone", ".claude"), result);
+    }
+
+    // ── GetLastSessionId ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetLastSessionId_ReturnsNewestSessionByWriteTime()
+    {
+        string dir = MakeProjectDir(_root, "C--Github-Foo");
+        WriteSession(dir, "11111111-1111-1111-1111-111111111111", new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc));
+        WriteSession(dir, "22222222-2222-2222-2222-222222222222", new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc));
+
+        string? id = ClaudeSessionService.GetLastSessionId(@"C:\Github\Foo", _root);
+
+        Assert.Equal("22222222-2222-2222-2222-222222222222", id);
+    }
+
+    [Fact]
+    public void GetLastSessionId_ReadsFromTheGivenClaudeHome_NotAHardcodedOne()
+    {
+        // The regression: a stale ~/.claude alongside a live CLAUDE_CONFIG_DIR. Only the
+        // session in the home we were handed may be returned.
+        string stale = Path.Combine(_root, "stale");
+        string live = Path.Combine(_root, "live");
+        WriteSession(MakeProjectDir(stale, "C--Github-Foo"), "5ta1e000-0000-0000-0000-000000000000",
+            new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc));
+        WriteSession(MakeProjectDir(live, "C--Github-Foo"), "11ve0000-0000-0000-0000-000000000000",
+            new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc));
+
+        string? id = ClaudeSessionService.GetLastSessionId(@"C:\Github\Foo", live);
+
+        Assert.Equal("11ve0000-0000-0000-0000-000000000000", id);
+    }
+
+    [Fact]
+    public void GetLastSessionId_ReturnsNull_WhenProjectDirDoesNotExist()
+    {
+        string? id = ClaudeSessionService.GetLastSessionId(@"C:\Github\NeverUsed", _root);
+
+        Assert.Null(id);
+    }
+
+    [Fact]
+    public void GetLastSessionId_ReturnsNull_WhenProjectDirHasNoSessions()
+    {
+        MakeProjectDir(_root, "C--Github-Empty");
+
+        string? id = ClaudeSessionService.GetLastSessionId(@"C:\Github\Empty", _root);
+
+        Assert.Null(id);
+    }
+
+    [Fact]
+    public void GetLastSessionId_IgnoresSubdirectoriesAndNonSessionFiles()
+    {
+        // Real layout has a <session-id>/ directory (subagent transcripts) next to the
+        // <session-id>.jsonl, plus a memory/ dir. Neither may be mistaken for a session.
+        string dir = MakeProjectDir(_root, "C--Github-Foo");
+        WriteSession(dir, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc));
+        Directory.CreateDirectory(Path.Combine(dir, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl"));
+        Directory.CreateDirectory(Path.Combine(dir, "memory"));
+        File.WriteAllText(Path.Combine(dir, "notes.txt"), "x");
+
+        string? id = ClaudeSessionService.GetLastSessionId(@"C:\Github\Foo", _root);
+
+        Assert.Equal("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", id);
+    }
+
+    [Fact]
+    public void GetLastSessionId_MapsDriveAndSeparatorsToProjectDirName()
+    {
+        string dir = MakeProjectDir(_root, "C--Github-umage-CodeShellManager");
+        WriteSession(dir, "cccccccc-cccc-cccc-cccc-cccccccccccc", new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        string? id = ClaudeSessionService.GetLastSessionId(@"C:\Github\umage\CodeShellManager", _root);
+
+        Assert.Equal("cccccccc-cccc-cccc-cccc-cccccccccccc", id);
+    }
+}


### PR DESCRIPTION
Fixes restored Claude sessions failing with **`No conversation found with session ID: <uuid>`**, leaving a bare shell prompt behind.

## Root cause

`ClaudeSessionService` hardcoded `~/.claude` as Claude's data directory:

```csharp
Path.Combine(UserProfile, ".claude", "projects", projectDir)
```

Claude Code honors **`CLAUDE_CONFIG_DIR`**, and when it's set, conversations live under `$CLAUDE_CONFIG_DIR/projects/` instead. A machine that has ever run *without* the env var keeps a stale `~/.claude/projects/` tree — so `GetLastSessionId` returned the newest id from the **wrong store**: a real, valid-looking UUID that current Claude has no record of.

This is why it looked like Claude had changed how `--resume` works. It hasn't; only *where* conversations are stored moved.

## Evidence from the reporting machine

`CLAUDE_CONFIG_DIR` is set at **User** scope, so `CodeShellManager.exe` inherits it. For one project folder:

| Store | Newest `.jsonl` |
|---|---|
| `~/.claude` (stale, frozen ~2 months) | `6270d0e9-971a-44ad-81b9-cf89434ab1cf` ← **exactly the id in the error** |
| `~/.claude-work` (live) | `8eaf0a22-4f5d-45a4-a579-0ccf20553e27`, modified same day |

## Change

- **`ResolveClaudeHome(configDir, userProfile)`** — `CLAUDE_CONFIG_DIR` when set, else `~/.claude`.
- **`GetLastSessionId`** gains an `internal` overload taking the resolved home, so the lookup is testable without mutating process environment or depending on the real user profile. **Public signature unchanged.**

This deliberately does **not** fall back to the legacy directory when the resolved one has no session — returning `null` starts a fresh conversation, which is correct. Falling back would reintroduce the bogus-id failure.

## Scope

Does **not** fix #75 (the same-folder resume race, where two sessions in one folder both resolve to the same id and the first session's own write poisons the lookup for the second). That's a separate root cause in the same code path; the durable fix there is persisting a `ClaudeSessionId` per session and launching with `--session-id`. This PR only ensures we read the *right directory*.

## Verification

- **9 new unit tests** — env resolution (set / null / blank), stale-vs-live store selection, missing and empty project dirs, path→project-dir-name mapping, and the real on-disk layout where a `<session-id>/` subdirectory and a `memory/` dir sit next to `<session-id>.jsonl`
- **215/215** tests pass; app builds clean
- Written test-first; watched each fail

**Manual check worth doing before merge:** restart CodeShellManager and confirm sessions resume rather than erroring. I verified the id resolution against the real filesystem but did not perform a live `--resume` (that would have written into an in-use conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)