### PR TITLE
chore(release): clear NU1903 advisory and silence CS8123 warnings

### DIFF
--- a/src/CodeShellManager/CodeShellManager.csproj
+++ b/src/CodeShellManager/CodeShellManager.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3967.48" />
   </ItemGroup>
 

--- a/src/CodeShellManager/Services/RunCommandTemplatesService.cs
+++ b/src/CodeShellManager/Services/RunCommandTemplatesService.cs
@@ -44,16 +44,16 @@ public static class RunCommandTemplatesService
         // Priority order: dotnet → cargo → node → python → make. First match wins.
         if (HasExt(".sln") || HasExt(".csproj"))
             return Build("dotnet",
-                ("Run",   "dotnet run",   isDefault: true),
-                ("Build", "dotnet build", isDefault: false),
-                ("Test",  "dotnet test",  isDefault: false));
+                ("Run",   "dotnet run",   IsDefault: true),
+                ("Build", "dotnet build", IsDefault: false),
+                ("Test",  "dotnet test",  IsDefault: false));
 
         if (Has("Cargo.toml"))
             return Build("cargo",
-                ("Run",    "cargo run",    isDefault: true),
-                ("Build",  "cargo build",  isDefault: false),
-                ("Test",   "cargo test",   isDefault: false),
-                ("Clippy", "cargo clippy", isDefault: false));
+                ("Run",    "cargo run",    IsDefault: true),
+                ("Build",  "cargo build",  IsDefault: false),
+                ("Test",   "cargo test",   IsDefault: false),
+                ("Clippy", "cargo clippy", IsDefault: false));
 
         if (Has("package.json"))
         {
@@ -66,21 +66,21 @@ public static class RunCommandTemplatesService
             // yarn's invocation differs slightly: `yarn start` (no `run`) is conventional.
             string runPrefix = pm == "yarn" ? "yarn" : $"{pm} run";
             return Build("node",
-                ("Start", $"{pm} start",         isDefault: true),
-                ("Test",  $"{pm} test",          isDefault: false),
-                ("Build", $"{runPrefix} build",  isDefault: false));
+                ("Start", $"{pm} start",         IsDefault: true),
+                ("Test",  $"{pm} test",          IsDefault: false),
+                ("Build", $"{runPrefix} build",  IsDefault: false));
         }
 
         if (Has("pyproject.toml") || Has("requirements.txt"))
             return Build("python",
-                ("Run",  "python main.py",     isDefault: true),
-                ("Test", "python -m pytest",   isDefault: false));
+                ("Run",  "python main.py",     IsDefault: true),
+                ("Test", "python -m pytest",   IsDefault: false));
 
         if (Has("Makefile") || Has("makefile"))
             return Build("make",
-                ("Run",   "make",       isDefault: true),
-                ("Test",  "make test",  isDefault: false),
-                ("Clean", "make clean", isDefault: false));
+                ("Run",   "make",       IsDefault: true),
+                ("Test",  "make test",  IsDefault: false),
+                ("Clean", "make clean", IsDefault: false));
 
         return null;
     }


### PR DESCRIPTION
Two pre-release cleanups ahead of tagging v0.6.0.

## Security: NU1903 (High)

`Microsoft.Data.Sqlite` 10.0.8 pulled `SQLitePCLRaw.lib.e_sqlite3` 2.1.11, which carries [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (High). It surfaced as `NU1903` on every build of both the app and the test project. Bumped to **10.0.11**.

> [!IMPORTANT]
> **10.0.10 — the version Dependabot proposes in #84 — does NOT resolve this.** It still resolves the vulnerable 2.1.11. Both versions were verified with `dotnet list package --vulnerable --include-transitive`. #84 is superseded by this PR and should be closed.

## Cleanup: CS8123 ×15

`RunCommandTemplatesService` labelled its tuple arguments `isDefault:` while `Build` declares the element as `IsDefault`, so the name was ignored and the compiler emitted `CS8123` fifteen times — most of the build's warning noise, which made a genuinely new warning easy to miss.

Matched the case at the call sites. Compile-time labels only; positional arguments and seeding behaviour are unchanged.

## Verification

| Check | Before | After |
|---|---|---|
| `dotnet list package --vulnerable` | 1 High | **clean** |
| Release build | 0 errors, 17 warnings | **0 errors, 0 warnings** |
| Unit tests | 222/222 | **222/222** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be