### PR TITLE
chore(release): set version to 0.6.0 and unpin FileVersion

### DIFF
--- a/src/CodeShellManager/CodeShellManager.csproj
+++ b/src/CodeShellManager/CodeShellManager.csproj
@@ -9,9 +9,11 @@
     <UseWindowsForms>true</UseWindowsForms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>CodeShellManager</RootNamespace>
-    <Version>0.3.4</Version>
-    <AssemblyVersion>0.3.4.0</AssemblyVersion>
-    <FileVersion>0.3.4.0</FileVersion>
+    <!-- Overridden by CI at publish time via -p:Version= from the git tag.
+         AssemblyVersion and FileVersion deliberately left unset so they derive from
+         this and stay in step; pinning them shipped binaries reporting 0.3.4.0 for
+         every release up to and including v0.5.0. -->
+    <Version>0.6.0</Version>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
Last piece of the v0.6.0 pre-release review — finding 04.

## Problem

`AssemblyVersion` and `FileVersion` were hardcoded to `0.3.4.0` in the csproj, while CI only overrides `Version` (via `-p:Version=` from the git tag). Those never meet, so the pinned values won.

Result: every release up to and including v0.5.0 shipped binaries where Windows' file-properties dialog reads **File version 0.3.4.0** against **Product version 0.5.0**. Anyone checking the version the normal Windows way — right-click → Properties → Details — got a wrong answer. Confirmed against the installed v0.5.0 build.

## Fix

Removed both pinned elements so they derive from `Version`, and set `Version` to `0.6.0` for local build clarity. CI still overrides it from the tag, so this stays correct for future releases instead of drifting again.

## Verification

CI-shaped publish (`-p:Version=0.6.0`) against this branch:

```
FileVersion    : 0.6.0.0                                    (was 0.3.4.0)
ProductVersion : 0.6.0+a13bca5e37da43cc7e6b77bfc0eec019d5b79152
```

No external consumers bind against this assembly, so the `AssemblyVersion` change is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be