### PR TITLE
ci(release): auto-sync winget fork and document the real release process

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -2,9 +2,14 @@ name: Publish to Chocolatey
 
 # Packs and pushes a Chocolatey package wrapping the signed MSI from a GitHub Release
 # to community.chocolatey.org.
-# - `release` event fires automatically when CI / Release publishes the GitHub Release.
-# - `workflow_dispatch` lets us re-publish a past version (used for the first
-#   submission once this workflow exists on main).
+# ⚠️ The `release` trigger below has never actually fired — every run in this repo's
+# history is a workflow_dispatch. Events raised by a workflow using the default
+# GITHUB_TOKEN do not trigger other workflows, and CI / Release creates the Release
+# with that token. **Dispatching this manually is the release process**:
+#
+#     gh workflow run chocolatey.yml -f tag=vX.Y.Z
+#
+# See CLAUDE.md → Releases for the full post-tag checklist.
 #
 # Requires repo secret CHOCO_API_KEY (from https://community.chocolatey.org/account)
 # scoped to push for package id `codeshellmanager`.

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,12 +1,22 @@
 name: Publish to WinGet
 
 # Submits the signed MSI from a GitHub Release to microsoft/winget-pkgs.
-# - `release` event fires automatically when CI / Release publishes the GitHub Release.
-# - `workflow_dispatch` lets us re-publish a past version (used for the very first
-#   submission once this workflow exists on main).
 #
-# Requires repo secret WINGET_TOKEN: a classic PAT with `public_repo` scope.
-# (winget-releaser does not yet support fine-grained tokens.)
+# ⚠️ THE `release` TRIGGER BELOW HAS NEVER ACTUALLY FIRED. Every run in this repo's
+# history is a workflow_dispatch. That is GitHub behaving as designed: events raised
+# by a workflow authenticated with the default GITHUB_TOKEN do not trigger other
+# workflows, and CI / Release creates the Release with exactly that token. So
+# **dispatching this manually is the release process**, not a fallback:
+#
+#     gh workflow run winget.yml -f tag=vX.Y.Z
+#
+# To make the automatic trigger real, CI / Release would need to create the Release
+# with a PAT instead of GITHUB_TOKEN. Left as-is deliberately — see CLAUDE.md.
+#
+# Requires repo secret WINGET_TOKEN: a classic PAT with `public_repo` scope
+# (winget-releaser does not support fine-grained tokens). `public_repo` IS enough —
+# if you hit a permissions-looking error, read the sync step below before touching
+# the token, because that error is almost never about the token.
 
 on:
   release:
@@ -25,6 +35,33 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      # ── Sync the fork before submitting ─────────────────────────────────────
+      # komac creates its release branch in OUR fork of winget-pkgs. Upstream lands
+      # dozens of commits a day, so a fork left alone between releases falls far
+      # enough behind that GitHub rejects the branch creation.
+      #
+      # The failure is badly disguised — it surfaces as
+      #     "<user> does not have the correct permissions to execute `CreateRef`"
+      #     "failed to create branch UmageAI.CodeShellManager-<version>-<hash>"
+      # which reads like a token-scope problem and is not one. v0.6.0 burned three
+      # regenerated PATs (including needlessly widening the scope to full `repo`)
+      # before the actual cause turned up. See komac#376 and winget-releaser#336.
+      #
+      # NOTE the fork komac uses is the one under the SAME OWNER as this repo —
+      # umage-ai/winget-pkgs — not a maintainer's personal fork. A personal fork of
+      # winget-pkgs may also exist; syncing that one does nothing. Override with the
+      # `fork-user` input if this ever needs to point elsewhere.
+      # continue-on-error: a sync hiccup must not block a submit that might still
+      # succeed, and if the submit then fails we want its real error, not this one.
+      - name: Sync umage-ai/winget-pkgs with upstream
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          gh api -X POST "repos/${{ github.repository_owner }}/winget-pkgs/merge-upstream" \
+            -f branch=master \
+            --jq '"sync: \(.merge_type) - \(.message)"'
+
       - name: Submit to winget-pkgs
         uses: vedantmgoyal9/winget-releaser@v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,9 +322,47 @@ git tag v1.2.3 -m "v1.2.3 - description"
 git push origin v1.2.3
 ```
 
-The tag value overrides the csproj `<Version>` at publish time (`-p:Version=` flag). **Do not rely on the csproj version number** — bump it for local build clarity only. CI produces a signed exe, MSI installer, and portable ZIP, then creates a GitHub Release automatically.
+The tag value overrides the csproj `<Version>` at publish time (`-p:Version=` flag). `AssemblyVersion` / `FileVersion` are deliberately **not** set in the csproj so they derive from `Version` — pinning them is what made every release through v0.5.0 ship binaries reporting `FileVersion 0.3.4.0`. CI produces a signed exe, MSI installer, and portable ZIP, then creates a GitHub Release automatically.
 
-A second workflow, `.github/workflows/winget.yml`, fires on the `release: released` event and submits the signed MSI to microsoft/winget-pkgs as `UmageAI.CodeShellManager` via [vedantmgoyal9/winget-releaser](https://github.com/vedantmgoyal9/winget-releaser). It needs the repo secret `WINGET_TOKEN` (classic PAT, `public_repo` scope). The same workflow is `workflow_dispatch`-able with a `tag` input to backfill or retry a release.
+### Pushing the tag is only half the release
+
+**The `release: released` triggers on `winget.yml` and `chocolatey.yml` have never fired.** Every run in the repo's history is a `workflow_dispatch`. This is GitHub behaving as designed: events raised by a workflow authenticated with the default `GITHUB_TOKEN` do not trigger other workflows, and `softprops/action-gh-release` creates the Release with exactly that token. Both workflows still *declare* the trigger, which makes it look automatic. It is not.
+
+**Post-tag checklist — required, not optional:**
+
+```bash
+# 1. wait for CI / Release to finish and the GitHub Release to exist
+# 2. then dispatch BOTH mirrors by hand
+gh workflow run winget.yml     -f tag=vX.Y.Z
+gh workflow run chocolatey.yml -f tag=vX.Y.Z
+# 3. watch both — they fail independently of CI and nothing else will tell you
+```
+
+To make it genuinely automatic, CI / Release would have to create the Release with a PAT rather than `GITHUB_TOKEN`.
+
+### winget: the `CreateRef` error is not about the token
+
+`winget.yml` submits the signed MSI to microsoft/winget-pkgs as `UmageAI.CodeShellManager` via [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser). Needs `WINGET_TOKEN` — a **classic** PAT with `public_repo` (fine-grained tokens are unsupported).
+
+When it fails you will see:
+
+```
+0: AThraen does not have the correct permissions to execute `CreateRef`
+1: failed to create branch UmageAI.CodeShellManager-<version>-<hash>
+```
+
+**This is almost never a token problem.** It means our fork of winget-pkgs is too far behind upstream for GitHub to accept the new branch. Upstream lands dozens of commits a day, so a fork untouched since the last release is always stale by the next one.
+
+Two traps that cost real time on v0.6.0:
+
+- **Sync the fork under the org, `umage-ai/winget-pkgs`** — komac uses the fork owned by the same account as this repo. A maintainer's *personal* fork (`AThraen/winget-pkgs`) may also exist and is a red herring; syncing it changes nothing.
+- **Don't widen the token scope.** `public_repo` is sufficient. winget-releaser's README once carried advice to use full `repo`; the PR proposing it was closed unmerged. Broadening the scope does not fix this and hands CI write access to every private repo the owner can reach.
+
+`winget.yml` now syncs the org fork automatically before submitting, so this should not recur. If it does, sync manually and re-dispatch:
+
+```bash
+gh api -X POST repos/umage-ai/winget-pkgs/merge-upstream -f branch=master
+```
 
 A third workflow, `.github/workflows/chocolatey.yml`, also fires on `release: released` and publishes the signed MSI to community.chocolatey.org as `codeshellmanager`. It downloads the MSI from the GitHub Release, computes its SHA256, substitutes `__URL64__` / `__CHECKSUM64__` placeholders in `.chocolatey/tools/chocolateyinstall.ps1`, then runs `choco pack` and `choco push`. Needs the repo secret `CHOCO_API_KEY` (API key from a chocolatey.org account with push rights on the `codeshellmanager` id). Also `workflow_dispatch`-able with a `tag` input. The `.chocolatey/` folder holds the package skeleton (`codeshellmanager.nuspec`, `tools/chocolateyinstall.ps1`, `tools/chocolateyuninstall.ps1`); never commit a resolved URL or checksum into the install script — those placeholders are only substituted by the workflow at pack time. The nuspec's `licenseUrl` points at the GitHub `LICENSE` file, so no bundled `LICENSE.txt`/`VERIFICATION.txt` is needed (Chocolatey moderator feedback on the v0.5.0 submission asked these to be removed, along with setting `owners` to the maintainer account rather than the org).
 


### PR DESCRIPTION
Publishing v0.6.0 to winget burned ~40 minutes and three regenerated PATs on an error that had nothing to do with the token. This makes that failure impossible and writes down the parts of the release that aren't automatic.

## The `CreateRef` error is a stale fork, not a token

```
0: AThraen does not have the correct permissions to execute `CreateRef`
1: failed to create branch UmageAI.CodeShellManager-0.6.0-<hash>
```

It names a user and a permission, so every instinct says rotate the token. It actually means our fork of `winget-pkgs` is too far behind upstream for GitHub to accept the new branch. Upstream lands dozens of commits a day, so a fork untouched since the last release is always stale by the next one.

Two traps worth recording, because both cost time:

- **komac uses the fork owned by the same account as this repo** — `umage-ai/winget-pkgs`. A personal `AThraen/winget-pkgs` fork also exists and is a red herring; syncing it changes nothing. Ours was last synced 2026-05-15 — the day v0.5.0 published.
- **`public_repo` is sufficient.** Widening to full `repo` does not fix this, and would hand CI write access to every private repo the owner can reach. winget-releaser's README once advised full `repo`; that PR ([#337](https://github.com/vedantmgoyal9/winget-releaser/pull/337)) was closed unmerged. See [komac#376](https://github.com/russellbanks/Komac/issues/376) and [winget-releaser#336](https://github.com/vedantmgoyal9/winget-releaser/issues/336).

`winget.yml` now syncs the org fork before submitting. The step is `continue-on-error` so a sync hiccup can't block a submit that might still succeed — and so a failing submit reports its own error rather than being masked by this one.

## The `release: released` trigger has never fired

Both mirror workflows declare it, but **every run in this repo's history is a `workflow_dispatch`**. Events raised by a workflow authenticated with the default `GITHUB_TOKEN` do not trigger other workflows, and `CI / Release` creates the Release with exactly that token.

So dispatching both by hand *is* the release process, not a fallback. Documented as a required post-tag checklist rather than changed — making it genuinely automatic means giving the release step a PAT, which is a separate decision.

## Also

Records why `AssemblyVersion` / `FileVersion` are deliberately absent from the csproj, so nobody re-pins them: that's what made every release through v0.5.0 ship binaries reporting `FileVersion 0.3.4.0`.

## Verification

v0.6.0 is submitted and live as [microsoft/winget-pkgs#420915](https://github.com/microsoft/winget-pkgs/pull/420915) — the run that produced it succeeded immediately after syncing `umage-ai/winget-pkgs`, with no token change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be