### PR TITLE
fix(terminal): make the pane you click or type in the active session

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -3600,6 +3600,18 @@ public partial class MainWindow : Window
             Tag = accent
         };
 
+        // Clicking anywhere in a pane makes that session active. Tunnelling (Preview)
+        // because the WebView2 swallows the bubbling event before it reaches us, and
+        // Handled is deliberately NOT set so the click still lands in the terminal.
+        //
+        // Without this, ActiveSession only followed sidebar clicks, so a pane clicked
+        // directly kept IsForeground=false and flushed its output at Background
+        // dispatcher priority — its own echo queued behind every other session's.
+        activeRing.PreviewMouseLeftButtonDown += (_, _) =>
+        {
+            if (!ReferenceEquals(_vm.ActiveSession, vm)) _vm.ActiveSession = vm;
+        };
+
         var outer = new DockPanel();
 
         // Terminal toolbar

--- a/src/CodeShellManager/ViewModels/MainViewModel.cs
+++ b/src/CodeShellManager/ViewModels/MainViewModel.cs
@@ -284,7 +284,24 @@ public partial class MainViewModel : ObservableObject
             // there), so it must stay cheap. NotifyUserInteracted already fires AlertCleared
             // unconditionally, whose handler below raises AlertCount — so this deliberately
             // does not raise it a second time (issue #70).
-            vm.Bridge.UserInput += () => vm.AlertDetector?.NotifyUserInteracted();
+            vm.Bridge.UserInput += () =>
+            {
+                // Typing into a pane makes it the active session.
+                //
+                // Without this, ActiveSession only moved when the user clicked a SIDEBAR
+                // row — there is no focus handler on the WebView2. So in a multi-pane
+                // layout, clicking straight into a pane and typing left ActiveSession on
+                // whatever the sidebar last selected, which left this bridge's
+                // IsForeground false, which made its output flush at Background
+                // dispatcher priority. The pane you are typing in rendered its own echo
+                // behind every other session's output — the #70 priority split working
+                // exactly as designed, against the wrong session.
+                //
+                // Guarded on reference equality: this runs per keystroke, and the assign
+                // fans out to UpdateActiveTerminalHighlight over every session.
+                if (!ReferenceEquals(ActiveSession, vm)) ActiveSession = vm;
+                vm.AlertDetector?.NotifyUserInteracted();
+            };
         }
 
         if (vm.AlertDetector != null)


### PR DESCRIPTION
Reported as "still kinda slow when typing" on v0.6.0, after #83 was supposed to fix exactly that.

## What was happening

#70 split terminal output by dispatcher priority — foreground bridges flush at `Normal`, background ones at `Background`, so a chatty background pane can't sit ahead of the active pane's rendering or its keystrokes.

That split reads `TerminalBridge.IsForeground`, which is only refreshed inside `UpdateActiveTerminalHighlight()`, which only runs when `MainViewModel.ActiveSession` changes.

`ActiveSession` had exactly four assignment sites: session created, session closed, startup, and the `FocusSession` command — **and `FocusSession` only fires from a sidebar row click.** Nothing on the WebView2 or the terminal wrapper touched it.

So clicking straight into a pane and typing left `IsForeground = false` on that bridge. Its output — including the echo of your own keystrokes — flushed at the *lowest* dispatcher priority, behind every other session's output.

The #70 priority split was working exactly as designed, against the wrong session. Which is why v0.6.0 didn't feel fixed: for the sidebar-selected pane it genuinely is, so the improvement is invisible if you mostly click into panes directly.

**Confirmed from the user side before fixing:** typing into a non-active pane did not move the sidebar's active indicator.

## Fix

Two promotion points, both guarded on reference equality so they no-op when the session is already active:

- **`PreviewMouseLeftButtonDown`** on the pane's active-ring border. Tunnelling, because WebView2 swallows the bubbling event before it reaches WPF. `Handled` is deliberately **not** set, so the click still lands in the terminal and places the cursor.
- **`UserInput`** on the bridge, which already fires per keystroke — catches focus arriving by any route the mouse handler misses.

The reference-equality guard matters: `UserInput` runs per keystroke, and assigning `ActiveSession` fans out to `UpdateActiveTerminalHighlight` across every session.

`OnActiveSessionChanged` is a no-op outside `InlineHeaders` group mode, so this adds no group-layout churn in the default `FilterStrip` mode.

## Verification

- Release build: 0 errors, 0 warnings
- Unit tests: 241/241
- Symptom reproduced and root cause confirmed by the reporter before the change

Most visible with many live panes in a multi-column layout — which is also the configuration #82 is about, so this likely accounts for part of that report too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be