### PR TITLE
fix(state): write state.json atomically with a backup and recover from it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ PTY (ConPTY) → PseudoTerminal → TerminalBridge → WebView2 (xterm.js)
 | Service | Purpose |
 |---|---|
 | `SessionManager` | CRUD for ShellSession models |
-| `StateService` | JSON persistence → `%AppData%/CodeShellManager/state.json` |
+| `StateService` | JSON persistence → `%AppData%/CodeShellManager/state.json`. Writes are **atomic**: serialize to `.tmp`, then `File.Replace` into place, rotating the previous file to `.bak`. `LoadAsync` falls back to `.bak` when the primary won't parse, and logs every step to `crash.log` rather than silently starting empty. A static `SemaphoreSlim` serializes saves — 29 of the ~32 `SaveStateAsync` call sites are fire-and-forget, and overlapping saves would otherwise race on the shared temp file. See issue #88. |
 | `SearchService` | SQLite FTS5 search of all terminal output; also owns the `project_notes` table |
 | `ColorService` | FNV-1a hash of folder path → 12-color palette |
 | `GitService` | Async `git branch --show-current` + `git status --porcelain` |

--- a/src/CodeShellManager/Services/StateService.cs
+++ b/src/CodeShellManager/Services/StateService.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using CodeShellManager.Models;
 
@@ -15,6 +16,15 @@ public class StateService
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "CodeShellManager", "state.json");
 
+    /// <summary>Scratch file for the atomic swap. Never read; deleted if a save fails.</summary>
+    private static string TempPath => StatePath + ".tmp";
+
+    /// <summary>One-generation backup, written for free by <see cref="File.Replace(string,string,string)"/>.</summary>
+    private static string BackupPath => StatePath + ".bak";
+
+    /// <summary>Serializes concurrent saves — see SaveAsync.</summary>
+    private static readonly SemaphoreSlim SaveGate = new(1, 1);
+
     private static readonly JsonSerializerOptions Options = new()
     {
         WriteIndented = true,
@@ -24,30 +34,126 @@ public class StateService
     /// <summary>Returns the resolved state file path (respects CSM_STATE_PATH env var).</summary>
     public static string GetPath() => StatePath;
 
+    /// <summary>
+    /// Loads persisted state, falling back to the backup if the primary file is
+    /// unreadable (issue #88).
+    ///
+    /// The file is rewritten on ~33 different UI actions, so an interrupted write is a
+    /// realistic way to end up with truncated JSON. Previously any failure here returned
+    /// an empty state silently — indistinguishable from a genuine first run — and the
+    /// next save then overwrote the damaged-but-recoverable file. Now we try the backup
+    /// first and log every step to crash.log so the loss is at least visible.
+    /// </summary>
     public async Task<AppState> LoadAsync()
+    {
+        var primary = await TryLoadAsync(StatePath);
+        if (primary != null) return Normalize(primary);
+
+        // Nothing on disk at all is the ordinary first-run case, not a failure.
+        if (!File.Exists(StatePath) && !File.Exists(BackupPath)) return new AppState();
+
+        Log($"state file at '{StatePath}' is unreadable — trying backup");
+
+        var backup = await TryLoadAsync(BackupPath);
+        if (backup != null)
+        {
+            Log("recovered state from backup");
+            return Normalize(backup);
+        }
+
+        Log("backup unusable as well — starting from empty state");
+        return new AppState();
+    }
+
+    private static async Task<AppState?> TryLoadAsync(string path)
     {
         try
         {
-            var path = StatePath;
-            if (!File.Exists(path)) return new AppState();
+            if (!File.Exists(path)) return null;
             string json = await File.ReadAllTextAsync(path);
-            return JsonSerializer.Deserialize<AppState>(json, Options) ?? new AppState();
+            return JsonSerializer.Deserialize<AppState>(json, Options);
         }
-        catch
+        catch (Exception ex)
         {
-            return new AppState();
+            Log($"failed to read '{path}': {ex.Message}");
+            return null;
         }
     }
 
+    /// <summary>
+    /// Coerces explicitly-null collections to empty.
+    ///
+    /// The property initialisers on <see cref="AppState"/> only apply when a key is
+    /// *absent*; an explicit <c>"Sessions": null</c> deserializes to a real null and
+    /// NREs on first use. We never write null (DefaultIgnoreCondition), but
+    /// <see cref="ImportExportService"/> will happily deserialize whatever JSON file
+    /// the user points at, so the loader can't assume its input came from us.
+    /// </summary>
+    private static AppState Normalize(AppState s)
+    {
+        s.Sessions ??= [];
+        s.Groups ??= [];
+        s.RecentlyClosed ??= [];
+        s.GroupLayouts ??= new();
+        s.Settings ??= new();
+        return s;
+    }
+
+    /// <summary>
+    /// Writes state atomically: serialize to a temp file, then swap it into place,
+    /// keeping the previous file as <c>state.json.bak</c> (issue #88).
+    ///
+    /// The swap is what matters — a crash mid-write damages the temp file, which
+    /// nothing reads, instead of the live one. A bare overwrite could leave the real
+    /// file truncated and take the whole workspace with it.
+    /// </summary>
     public async Task SaveAsync(AppState state)
+    {
+        // Serialize saves. 29 of the ~32 SaveStateAsync call sites are fire-and-forget,
+        // so overlapping writes are routine rather than exotic. Without this gate two
+        // saves race on the same temp file, and one can File.Replace the other's
+        // half-written content into the live file — manufacturing exactly the torn
+        // state this method exists to prevent.
+        await SaveGate.WaitAsync();
+        var path = StatePath;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            string json = JsonSerializer.Serialize(state, Options);
+
+            await File.WriteAllTextAsync(TempPath, json);
+
+            if (File.Exists(path))
+                // Atomic on NTFS, and rotates the old file into .bak in one step.
+                // ignoreMetadataErrors: ACL/attribute copy failures must not fail the save.
+                File.Replace(TempPath, path, BackupPath, ignoreMetadataErrors: true);
+            else
+                File.Move(TempPath, path);   // first write — nothing to back up or replace
+        }
+        catch (Exception ex)
+        {
+            Log($"save failed: {ex.Message}");
+            // Leave the live file alone; just clear the scratch file so it can't be
+            // mistaken for real state or block the next save.
+            try { if (File.Exists(TempPath)) File.Delete(TempPath); }
+            catch { /* best effort */ }
+        }
+        finally
+        {
+            SaveGate.Release();
+        }
+    }
+
+    private static void Log(string message)
     {
         try
         {
-            var path = StatePath;
-            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            string json = JsonSerializer.Serialize(state, Options);
-            await File.WriteAllTextAsync(path, json);
+            string logPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "CodeShellManager", "crash.log");
+            Directory.CreateDirectory(Path.GetDirectoryName(logPath)!);
+            File.AppendAllText(logPath, $"[{DateTime.Now:HH:mm:ss.fff}] StateService: {message}\n");
         }
-        catch { /* non-critical */ }
+        catch { /* logger failure is not actionable */ }
     }
 }

--- a/tests/CodeShellManager.Tests/StateServiceTests.cs
+++ b/tests/CodeShellManager.Tests/StateServiceTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using CodeShellManager.Models;
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="StateService"/> durability (issue #88).
+///
+/// The state file is rewritten on ~33 different UI actions, so an interrupted write
+/// is a realistic way to lose the whole workspace. These cover the atomic swap, the
+/// one-generation backup, recovery from a torn primary, and the null-list tolerance
+/// that <c>ImportExportService</c> can otherwise trip over.
+///
+/// Each test points <c>CSM_STATE_PATH</c> at its own temp file and cleans up after.
+/// </summary>
+public class StateServiceTests : IDisposable
+{
+    private readonly string _path;
+    private readonly StateService _svc = new();
+
+    public StateServiceTests()
+    {
+        _path = Path.Combine(Path.GetTempPath(), $"csm-state-{Guid.NewGuid():N}.json");
+        Environment.SetEnvironmentVariable("CSM_STATE_PATH", _path);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("CSM_STATE_PATH", null);
+        foreach (var p in new[] { _path, _path + ".bak", _path + ".tmp" })
+            if (File.Exists(p)) File.Delete(p);
+    }
+
+    private static AppState WithSessions(params string[] ids)
+    {
+        var s = new AppState();
+        foreach (var id in ids)
+            s.Sessions.Add(new ShellSession { Id = id, WorkingFolder = $@"C:\{id}", Command = "claude" });
+        return s;
+    }
+
+    // ── atomic write + backup ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Save_FirstWrite_CreatesFileAndNoBackup()
+    {
+        await _svc.SaveAsync(WithSessions("a"));
+
+        Assert.True(File.Exists(_path));
+        Assert.False(File.Exists(_path + ".bak"));   // nothing to back up yet
+        Assert.False(File.Exists(_path + ".tmp"));   // scratch file must not linger
+    }
+
+    [Fact]
+    public async Task Save_SecondWrite_PreviousContentGoesToBackup()
+    {
+        await _svc.SaveAsync(WithSessions("first"));
+        await _svc.SaveAsync(WithSessions("second"));
+
+        Assert.Contains("second", await File.ReadAllTextAsync(_path));
+        Assert.True(File.Exists(_path + ".bak"));
+        Assert.Contains("first", await File.ReadAllTextAsync(_path + ".bak"));
+        Assert.False(File.Exists(_path + ".tmp"));
+    }
+
+    [Fact]
+    public async Task Save_RoundTripsSessions()
+    {
+        await _svc.SaveAsync(WithSessions("x", "y", "z"));
+        var loaded = await _svc.LoadAsync();
+
+        Assert.Equal(3, loaded.Sessions.Count);
+        Assert.Equal(new[] { "x", "y", "z" }, loaded.Sessions.ConvertAll(s => s.Id));
+    }
+
+    // ── recovery ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Load_TornPrimary_RecoversFromBackup()
+    {
+        await _svc.SaveAsync(WithSessions("good"));   // becomes the .bak
+        await _svc.SaveAsync(WithSessions("newer"));
+
+        // Simulate a write interrupted partway through.
+        await File.WriteAllTextAsync(_path, "{\"Sessions\":[{\"Id\":\"tru");
+
+        var loaded = await _svc.LoadAsync();
+
+        Assert.Single(loaded.Sessions);
+        Assert.Equal("good", loaded.Sessions[0].Id);
+    }
+
+    [Fact]
+    public async Task Load_TornPrimaryAndNoBackup_ReturnsEmptyRatherThanThrowing()
+    {
+        await File.WriteAllTextAsync(_path, "{\"Sessions\":[{\"Id\":\"tru");
+
+        var loaded = await _svc.LoadAsync();
+
+        Assert.NotNull(loaded);
+        Assert.Empty(loaded.Sessions);
+    }
+
+    [Fact]
+    public async Task Load_MissingFile_ReturnsEmpty()
+    {
+        var loaded = await _svc.LoadAsync();
+
+        Assert.NotNull(loaded);
+        Assert.Empty(loaded.Sessions);
+        Assert.Empty(loaded.Groups);
+    }
+
+    // ── null tolerance (ImportExportService can hand us anything) ────────────
+
+    [Fact]
+    public async Task Load_ExplicitNullLists_AreCoercedToEmpty()
+    {
+        await File.WriteAllTextAsync(_path,
+            """{"Sessions":null,"Groups":null,"RecentlyClosed":null,"GroupLayouts":null,"LastLayout":"Single"}""");
+
+        var loaded = await _svc.LoadAsync();
+
+        // Property initialisers only apply when the key is absent, not when it is
+        // explicitly null — so these must be coerced or every caller NREs.
+        Assert.NotNull(loaded.Sessions);
+        Assert.NotNull(loaded.Groups);
+        Assert.NotNull(loaded.RecentlyClosed);
+        Assert.NotNull(loaded.GroupLayouts);
+    }
+
+    [Fact]
+    public async Task Load_ValidJsonWrongShape_ReturnsEmpty()
+    {
+        await File.WriteAllTextAsync(_path, """["not","an","appstate"]""");
+
+        var loaded = await _svc.LoadAsync();
+
+        Assert.NotNull(loaded);
+        Assert.Empty(loaded.Sessions);
+    }
+
+    // ── back-compat: a pre-0.6.0 file must still load ────────────────────────
+
+    [Fact]
+    public async Task Load_PreV060File_DefaultsNewFieldsSafely()
+    {
+        await File.WriteAllTextAsync(_path, """
+            {"Sessions":[{"Id":"a","WorkingFolder":"C:\\p","Command":"claude",
+              "RunCommands":[{"Id":"r","Label":"Run","CommandLine":"npm run dev","IsDefault":true}]}],
+             "Groups":[],"LastLayout":"SixColumn"}
+            """);
+
+        var loaded = await _svc.LoadAsync();
+
+        Assert.Single(loaded.Sessions);
+        Assert.Empty(loaded.RecentlyClosed);                       // key absent pre-0.6.0
+        var rc = Assert.Single(loaded.Sessions[0].RunCommands);
+        Assert.Equal(RunMode.Process, rc.Mode);                    // historical behaviour
+        Assert.Null(rc.PostRunUrl);
+    }
+}

--- a/tests/CodeShellManager.Tests/StateServiceTests.cs
+++ b/tests/CodeShellManager.Tests/StateServiceTests.cs
@@ -78,6 +78,31 @@ public class StateServiceTests : IDisposable
         Assert.Equal(new[] { "x", "y", "z" }, loaded.Sessions.ConvertAll(s => s.Id));
     }
 
+    [Fact]
+    public async Task Save_ManyConcurrentSaves_LeaveAValidFileAndNoTempFile()
+    {
+        // 29 of the ~32 SaveStateAsync call sites are fire-and-forget, so overlapping
+        // saves are routine. They share one temp file, so without serialization one
+        // save can swap another's half-written content into the live file. This also
+        // catches a semaphore that is acquired but never released — that would hang
+        // here rather than fail.
+        var saves = new List<Task>();
+        for (int i = 0; i < 40; i++)
+        {
+            var s = WithSessions($"s{i}");
+            saves.Add(_svc.SaveAsync(s));
+        }
+
+        await Task.WhenAll(saves).WaitAsync(TimeSpan.FromSeconds(30));
+
+        Assert.False(File.Exists(_path + ".tmp"));
+
+        // Whichever save landed last, the file must be complete and parseable.
+        var loaded = await _svc.LoadAsync();
+        Assert.Single(loaded.Sessions);
+        Assert.StartsWith("s", loaded.Sessions[0].Id);
+    }
+
     // ── recovery ─────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #88.

## The failure chain

`SaveAsync` did a bare `File.WriteAllTextAsync`; `LoadAsync` caught everything and returned an empty `AppState`. With ~32 save call sites — layout changes, session open/close/sleep, group edits — the file is rewritten constantly, so an interrupted write was a realistic way to lose the whole workspace:

1. Write interrupted → truncated JSON on disk.
2. Next launch loads it, throws, **silently returns empty state** — the user sees zero sessions and no error, indistinguishable from a genuine first run.
3. Any save trigger then overwrites the damaged-but-recoverable file.

A real state file here is ~29KB with 40 sessions, 5 groups and 7 group layouts.

## Fix

- **Atomic swap.** Serialize to `state.json.tmp`, then `File.Replace` swaps it into place and rotates the previous file to `state.json.bak` in one step. A crash mid-write damages the temp file, which nothing reads.
- **Recover, don't discard.** `LoadAsync` falls back to `.bak` when the primary won't parse, logging each step to `crash.log`. Empty state is now the last resort, not the first response.
- **Null coercion.** Property initialisers only apply when a key is *absent*, so `"Sessions": null` deserialized to a real null and NREd on first use. We never write null, but `ImportExportService` deserializes whatever file the user points at.

## The part that wasn't in the issue

Making the write atomic introduced a new race that the old code didn't have. 29 of the ~32 call sites are **fire-and-forget** (`_ = SaveStateAsync()`), so overlapping saves are routine — and they share one temp file. Save A writes tmp, save B overwrites it mid-flight, A calls `File.Replace` with B's partial content, and the live file gets torn. That would have manufactured exactly the corruption this PR exists to prevent.

A static `SemaphoreSlim` serializes saves. The concurrency test fires 40 at once; note it would **hang** rather than fail if the release were ever dropped, which is deliberate — it caught precisely that during development.

## Tests

10 new, covering: atomic swap, backup rotation, no lingering temp file, torn primary recovering from backup, both-corrupt falling back to empty, missing file, null coercion, valid-JSON-wrong-shape, 40 concurrent saves, and a pre-0.6.0 file still loading with new fields defaulted.

| Check | Result |
|---|---|
| Unit tests | **251/251** (241 + 10) |
| App + Tests build | 0 errors, 0 warnings |

## Not included

The issue floated "refuse to save when load failed and recovery also failed." Left out deliberately — with `.bak` recovery in place the case is much rarer, and suppressing saves needs a `MainViewModel` state flag whose failure mode (silently never persisting) is worse than the one it prevents. Worth revisiting only if the logs show it happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be