### PR TITLE
refactor(pwsh): one PowerShell locator instead of two disagreeing ones

### DIFF
--- a/src/CodeShellManager/Services/PwshLocator.cs
+++ b/src/CodeShellManager/Services/PwshLocator.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Diagnostics;
+
+namespace CodeShellManager.Services;
+
+/// <summary>
+/// Decides once per process whether to spell PowerShell as <c>pwsh.exe</c> (7+) or
+/// <c>powershell.exe</c> (Windows-bundled 5.1).
+///
+/// Two callers need this and used to answer it separately:
+///   - <see cref="RunInstance"/>, wrapping a RunMode.PowerShell run command.
+///   - <see cref="Terminal.PseudoTerminal"/>, wrapping a non-shell session command so
+///     the shell sets up the Win32 console before the target process launches.
+///
+/// Prefer pwsh because that is where modern users keep their profile functions —
+/// wrapping in 5.1 loads a different profile and won't see them.
+///
+/// We only pick a *name*; CreateProcess resolves PATH. So a PATH lookup is the whole
+/// question, and <c>where.exe</c> answers it in ~10ms. The earlier RunInstance version
+/// spawned <c>pwsh -Command "exit 0"</c> instead, which additionally proved pwsh could
+/// actually run — but at the cost of a full PowerShell startup (hundreds of ms) on a
+/// path that runs during session restore. Not worth it for the rare broken install:
+/// that case now surfaces as a failed session rather than a slower launch for everyone.
+/// </summary>
+internal static class PwshLocator
+{
+    private static readonly Lazy<string> s_executable = new(Resolve);
+
+    /// <summary>
+    /// <c>"pwsh.exe"</c> when PowerShell 7+ is on PATH, otherwise <c>"powershell.exe"</c>.
+    /// Resolved on first use and cached for the process lifetime.
+    /// </summary>
+    internal static string Executable => s_executable.Value;
+
+    private static string Resolve()
+    {
+        Process? probe = null;
+        try
+        {
+            probe = Process.Start(new ProcessStartInfo
+            {
+                FileName = "where.exe",
+                Arguments = "pwsh.exe",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                // Redirected so a match doesn't print into whatever console we inherit.
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            });
+
+            // A hung lookup is treated as "not available" rather than blocking startup.
+            if (probe != null && probe.WaitForExit(2000) && probe.ExitCode == 0)
+                return "pwsh.exe";
+        }
+        catch { /* where.exe missing or blocked by policy — fall through */ }
+        finally
+        {
+            try { if (probe is { HasExited: false }) probe.Kill(entireProcessTree: true); }
+            catch { /* best effort */ }
+            probe?.Dispose();
+        }
+
+        return "powershell.exe";
+    }
+}

--- a/src/CodeShellManager/Services/RunInstance.cs
+++ b/src/CodeShellManager/Services/RunInstance.cs
@@ -208,48 +208,11 @@ public partial class RunInstance : ObservableObject, IDisposable
     internal static string BuildLocalCmd(string commandLine) => $"/c \"{commandLine}\"";
 
     /// <summary>
-    /// Returns "pwsh.exe" if PowerShell 7+ is on PATH, otherwise falls back to
-    /// the Windows-bundled "powershell.exe". ConPTY's CreateProcess resolves PATH
-    /// for us — we just pick which name to ask for.
+    /// Returns "pwsh.exe" if PowerShell 7+ is on PATH, otherwise "powershell.exe".
+    /// Delegates to <see cref="PwshLocator"/> so this and PseudoTerminal's session
+    /// wrapper can never disagree about which shell the machine has.
     /// </summary>
-    internal static string ResolvePwsh()
-    {
-        // Cheap check: try to spawn pwsh -NoLogo -Command "exit". If it returns,
-        // we trust pwsh is on PATH. Use a one-shot Process so we don't perturb
-        // the user's environment. Skip the probe if we already know.
-        if (_pwshResolved is { } cached) return cached;
-
-        try
-        {
-            using var probe = Process.Start(new ProcessStartInfo
-            {
-                FileName = "pwsh.exe",
-                Arguments = "-NoLogo -NoProfile -Command \"exit 0\"",
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-            });
-            if (probe != null)
-            {
-                // Cache pwsh only if the probe actually exited cleanly. A hung probe
-                // (WaitForExit returns false) or non-zero exit means pwsh is in a bad
-                // state; fall back to powershell.exe instead of caching a broken choice.
-                if (probe.WaitForExit(2000) && probe.ExitCode == 0)
-                {
-                    _pwshResolved = "pwsh.exe";
-                    return _pwshResolved;
-                }
-                try { if (!probe.HasExited) probe.Kill(entireProcessTree: true); }
-                catch { }
-            }
-        }
-        catch { /* not on PATH */ }
-
-        _pwshResolved = "powershell.exe";
-        return _pwshResolved;
-    }
-    private static string? _pwshResolved;
+    internal static string ResolvePwsh() => PwshLocator.Executable;
 
     /// <summary>
     /// Builds powershell args using -EncodedCommand so we don't have to worry

--- a/src/CodeShellManager/Terminal/PseudoTerminal.cs
+++ b/src/CodeShellManager/Terminal/PseudoTerminal.cs
@@ -175,29 +175,9 @@ public sealed class PseudoTerminal : IPseudoTerminal
     // Resolved once per process. pwsh (PowerShell 7+) is preferred because that's
     // where modern users keep their profile functions — wrapping in legacy
     // powershell.exe (5.1) loads a different profile and won't see them.
-    private static readonly Lazy<string> s_wrapperShell = new(ResolveWrapperShell);
-
-    private static string ResolveWrapperShell()
-    {
-        try
-        {
-            using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = "where.exe",
-                Arguments = "pwsh.exe",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            });
-            p?.WaitForExit(2000);
-            if (p?.ExitCode == 0) return "pwsh.exe";
-        }
-        catch { }
-        return "powershell.exe";
-    }
-
+    // Shared with RunInstance so both PowerShell-wrapping paths agree — see PwshLocator.
     internal static string BuildCmdLine(string command, string fullUserCmd)
-        => BuildCmdLine(command, fullUserCmd, s_wrapperShell.Value);
+        => BuildCmdLine(command, fullUserCmd, Services.PwshLocator.Executable);
 
     internal static string BuildCmdLine(string command, string fullUserCmd, string wrapperShell)
     {


### PR DESCRIPTION
Follow-up to #68, as flagged in the v0.6.0 review.

## Problem

Merging #68 left the codebase answering "pwsh or powershell?" in two places, with two different mechanisms:

| | Mechanism | Cost |
|---|---|---|
| `RunInstance.ResolvePwsh` | spawn `pwsh -NoLogo -NoProfile -Command "exit 0"`, cache on clean exit | full PowerShell startup, hundreds of ms |
| `PseudoTerminal.ResolveWrapperShell` | `where.exe pwsh.exe`, check exit code | ~10ms |

Same question, two answers possible, and both hand-rolled their own caching.

## Fix

One `Services/PwshLocator`, keeping the `where.exe` approach.

We only pick a *name* — `CreateProcess` resolves PATH — so a PATH lookup is the whole question. The probe additionally proved pwsh could actually *run*, but it paid a full PowerShell startup on a path that executes during **session restore**, which is exactly what #82 is about. A broken-but-on-PATH pwsh now surfaces as a failed session rather than a slower launch for everyone. That's the one behavioural trade-off in this PR and it's deliberate.

Merged the best of both: kept the hang timeout and kill-on-timeout from the `RunInstance` version (which `PseudoTerminal`'s lacked), and the stdout/stderr redirect from it too, so a match can't print into an inherited console.

`RunInstance.ResolvePwsh` stays as a one-line delegate — it reads better at the call site than reaching across namespaces for it.

## Compatibility

`PseudoTerminal.BuildCmdLine` keeps its injectable-shell overload, so #68's tests are untouched.

| Check | Result |
|---|---|
| Unit tests | **269/269** |
| App + Tests build | 0 errors, 0 warnings |
| Duplicate resolvers remaining | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be