### PR TITLE
perf(startup): gate Claude launches on the config file settling, not a flat 2s

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -277,6 +277,10 @@ public partial class MainWindow : Window
             // so simultaneous boots can corrupt the user's profile.
             int staggerMs = _vm.Settings.ClaudeLaunchStaggerMs;
             bool lastWasClaude = false;
+            // Last-write time of Claude's config captured just before the previous
+            // Claude launch, so the gate below can tell whether that launch has
+            // finished writing yet. See ClaudeConfigGate (issue #82).
+            DateTime? prevClaudeCfgBaseline = null;
             // WebView2 user-data folder access-denied is a common shared-failure
             // when another instance is running. Batch these so the user gets one
             // actionable dialog at the end instead of N "Restore Error" popups.
@@ -285,8 +289,19 @@ public partial class MainWindow : Window
             {
                 if (s.IsDormant) continue;
                 bool isClaude = ClaudeSessionService.IsClaudeCommand(s.Command);
+
+                // Wait for the PREVIOUS Claude to finish rewriting its config rather
+                // than sleeping a flat staggerMs. Same protection, but it costs what it
+                // actually takes instead of the worst case every time — 19 consecutive
+                // Claude sessions used to mean 38s of pure sleep. Capped at staggerMs,
+                // so this can never be slower than the old behaviour.
                 if (isClaude && lastWasClaude && staggerMs > 0)
-                    await Task.Delay(staggerMs);
+                    await WaitForClaudeConfigQuiesceAsync(prevClaudeCfgBaseline, staggerMs);
+
+                // Baseline BEFORE launching — a fast write would otherwise land before
+                // the first poll and read as "never written".
+                if (isClaude) prevClaudeCfgBaseline = ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath);
+
                 try { await LaunchSessionAsync(s, restoring: true); }
                 catch (Exception ex)
                 {
@@ -556,11 +571,16 @@ public partial class MainWindow : Window
         int staggerMs = _vm.Settings.ClaudeLaunchStaggerMs;
         string anchorId = primary.Id;
         bool lastWasClaude = ClaudeSessionService.IsClaudeCommand(primary.Command);
+        DateTime? prevClaudeCfgBaseline = lastWasClaude
+            ? ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath) : null;
         foreach (var path in additionalPaths)
         {
             if (!System.IO.Directory.Exists(path)) continue;
             bool isClaude = ClaudeSessionService.IsClaudeCommand(primary.Command);
-            if (isClaude && lastWasClaude && staggerMs > 0) await Task.Delay(staggerMs);
+            // Adaptive gate rather than a flat sleep — see the restore loop in OnLoaded.
+            if (isClaude && lastWasClaude && staggerMs > 0)
+                await WaitForClaudeConfigQuiesceAsync(prevClaudeCfgBaseline, staggerMs);
+            if (isClaude) prevClaudeCfgBaseline = ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath);
             var sibling = _sessionManager.CreateSession(
                 System.IO.Path.GetFileName(path.TrimEnd('/', '\\')) ?? primary.Command,
                 path,
@@ -4884,10 +4904,21 @@ public partial class MainWindow : Window
         foreach (var vm in all)
         {
             if (!ClaudeSessionService.IsClaudeCommand(vm.Command)) continue;
+
+            // Baseline before the process is signalled, so the gate below can see the
+            // shutdown write land.
+            DateTime? cfgBefore = ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath);
+
             await DisposeAndWaitForExitAsync(vm, timeoutMs: 10000);
-            // Small post-exit pause as belt-and-braces in case ~/.claude.json's write
-            // continues after the parent's shutdown signal but before its handles close.
-            if (postExitMs > 0) await Task.Delay(Math.Min(postExitMs, 1000));
+
+            // The exit wait above is on the process handle, but Claude's config write can
+            // still be in flight when the handle closes — hence a post-exit pause. This
+            // used to be a flat sleep of up to 1s per session (20s across 20 sessions)
+            // justified as belt-and-braces. Now it waits for the write to actually settle
+            // and returns as soon as it has, capped at the same 1s so the worst case is
+            // unchanged (issue #82).
+            if (postExitMs > 0)
+                await WaitForClaudeConfigQuiesceAsync(cfgBefore, Math.Min(postExitMs, 1000));
         }
 
         // OutputIndexer.Dispose now drains its worker first, but SqliteConnection.Close
@@ -4917,6 +4948,27 @@ public partial class MainWindow : Window
     /// disposes the VM. Used for claude sessions on app close so consecutive
     /// <c>~/.claude.json</c> writes can't overlap.
     /// </summary>
+    /// <summary>
+    /// Claude's config file, resolved once. Honours CLAUDE_CONFIG_DIR — with that set
+    /// the file lives inside it, not at %USERPROFILE%\.claude.json, and watching the
+    /// wrong one means always waiting the full cap.
+    /// </summary>
+    private readonly string _claudeConfigPath = ClaudeConfigGate.ResolveConfigFile();
+
+    /// <summary>
+    /// Blocks until Claude's config file has been written and gone quiet, or
+    /// <paramref name="capMs"/> elapses. Replaces a flat <c>Task.Delay(staggerMs)</c>
+    /// between consecutive Claude launches (issue #82).
+    /// </summary>
+    private Task WaitForClaudeConfigQuiesceAsync(DateTime? baseline, int capMs) =>
+        ClaudeConfigGate.WaitForQuiesceAsync(
+            baseline,
+            () => ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath),
+            () => DateTime.UtcNow,
+            Task.Delay,
+            TimeSpan.FromMilliseconds(capMs),
+            ClaudeConfigGate.DefaultQuietFor);
+
     private static async Task DisposeAndWaitForExitAsync(SessionViewModel vm, int timeoutMs)
     {
         var pty = vm.Pty;

--- a/src/CodeShellManager/Services/ClaudeConfigGate.cs
+++ b/src/CodeShellManager/Services/ClaudeConfigGate.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace CodeShellManager.Services;
+
+/// <summary>
+/// Spaces out consecutive Claude launches by watching Claude's config file settle,
+/// instead of sleeping a fixed <see cref="Models.AppSettings.ClaudeLaunchStaggerMs"/>
+/// between each one (issue #82).
+///
+/// Why the stagger exists: the Claude CLI rewrites its config on startup, and two
+/// claude.exe processes doing that at once can lose one another's updates. Evidence
+/// that this is real, not theoretical — a machine here has two orphaned
+/// <c>.claude.json.tmp.&lt;pid&gt;.&lt;hash&gt;</c> files with the same timestamp and
+/// different pids, left behind by two writers racing.
+///
+/// Why a fixed delay is the wrong shape: it pays the worst case every time. Restoring
+/// 20 Claude sessions spent 19 × 2s = 38 seconds purely asleep. Watching the file
+/// instead costs whatever it actually takes — usually a few hundred milliseconds —
+/// and the cap keeps the worst case exactly where it was.
+/// </summary>
+internal static class ClaudeConfigGate
+{
+    /// <summary>How long the file must stay unchanged before we call it settled.</summary>
+    internal static readonly TimeSpan DefaultQuietFor = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Resolves the config file Claude actually writes.
+    ///
+    /// Note the layout differs between the two cases, so this is not just
+    /// <see cref="ClaudeSessionService.ResolveClaudeHome"/> plus a filename:
+    ///   default            -> %USERPROFILE%\.claude.json   (a *sibling* of ~/.claude)
+    ///   CLAUDE_CONFIG_DIR  -> %CLAUDE_CONFIG_DIR%\.claude.json  (*inside* it)
+    ///
+    /// Getting this wrong means watching a file nobody writes and always waiting the
+    /// full cap — which is how it behaves today on any machine with the env var set.
+    /// </summary>
+    internal static string ResolveConfigFile(string? configDir, string userProfile) =>
+        string.IsNullOrWhiteSpace(configDir)
+            ? Path.Combine(userProfile, ".claude.json")
+            : Path.Combine(configDir, ".claude.json");
+
+    /// <summary>Live resolution against the current environment.</summary>
+    internal static string ResolveConfigFile() =>
+        ResolveConfigFile(
+            Environment.GetEnvironmentVariable("CLAUDE_CONFIG_DIR"),
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+    /// <summary>Last-write time of <paramref name="path"/>, or null if it isn't there.</summary>
+    internal static DateTime? LastWriteUtcOrNull(string path)
+    {
+        try { return File.Exists(path) ? File.GetLastWriteTimeUtc(path) : null; }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Waits until the config file has changed from <paramref name="baseline"/> and then
+    /// stayed unchanged for <paramref name="quietFor"/>, or until <paramref name="cap"/>
+    /// elapses — whichever comes first.
+    ///
+    /// If no write is ever observed we wait the full cap, deliberately: that is exactly
+    /// today's behaviour, so a machine where the file can't be watched is never worse
+    /// off than before. Take the baseline *before* launching, or a fast write lands
+    /// before the first poll and looks like no write at all.
+    ///
+    /// Clock and I/O are injected so the state machine is unit-testable without real
+    /// files or real time.
+    /// </summary>
+    internal static async Task WaitForQuiesceAsync(
+        DateTime? baseline,
+        Func<DateTime?> lastWriteUtc,
+        Func<DateTime> utcNow,
+        Func<int, Task> delayAsync,
+        TimeSpan cap,
+        TimeSpan quietFor,
+        int pollMs = 50)
+    {
+        if (cap <= TimeSpan.Zero) return;
+
+        DateTime start = utcNow();
+        DateTime? seen = baseline;
+        DateTime? changedAt = null;
+
+        while (utcNow() - start < cap)
+        {
+            await delayAsync(pollMs);
+
+            DateTime? current = lastWriteUtc();
+            if (current != seen)
+            {
+                seen = current;
+                changedAt = utcNow();
+                continue;
+            }
+
+            // Unchanged since the last poll. Only counts as settled once we've actually
+            // seen a write — otherwise a file Claude hasn't touched yet would let the
+            // next launch start immediately, which is the race we're preventing.
+            if (changedAt is { } t && utcNow() - t >= quietFor) return;
+        }
+    }
+}

--- a/tests/CodeShellManager.Tests/ClaudeConfigGateTests.cs
+++ b/tests/CodeShellManager.Tests/ClaudeConfigGateTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// Tests for the adaptive Claude launch gate (issue #82). Clock and file-time reads
+/// are injected, so these drive the state machine with a fake clock — no real files,
+/// no real waiting.
+/// </summary>
+public class ClaudeConfigGateTests
+{
+    // ── config file resolution ──────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveConfigFile_NoEnvVar_IsSiblingOfClaudeDir()
+    {
+        // Default layout puts .claude.json NEXT TO ~/.claude, not inside it.
+        Assert.Equal(@"C:\Users\bob\.claude.json",
+            ClaudeConfigGate.ResolveConfigFile(null, @"C:\Users\bob"));
+    }
+
+    [Fact]
+    public void ResolveConfigFile_WithEnvVar_IsInsideThatDir()
+    {
+        Assert.Equal(@"C:\Users\bob\.claude-work\.claude.json",
+            ClaudeConfigGate.ResolveConfigFile(@"C:\Users\bob\.claude-work", @"C:\Users\bob"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveConfigFile_BlankEnvVar_FallsBackToProfile(string configDir)
+    {
+        Assert.Equal(@"C:\Users\bob\.claude.json",
+            ClaudeConfigGate.ResolveConfigFile(configDir, @"C:\Users\bob"));
+    }
+
+    // ── the wait state machine ──────────────────────────────────────────────
+
+    /// <summary>Fake clock: every awaited delay advances virtual time instantly.</summary>
+    private sealed class Clock
+    {
+        public DateTime Now = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public readonly List<int> Waits = new();
+        public Task Delay(int ms) { Waits.Add(ms); Now = Now.AddMilliseconds(ms); return Task.CompletedTask; }
+        public int TotalWaitedMs { get { int t = 0; foreach (var w in Waits) t += w; return t; } }
+    }
+
+    [Fact]
+    public async Task Wait_WriteThenQuiet_ReturnsEarlyNotAtTheCap()
+    {
+        var clock = new Clock();
+        var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        DateTime? current = baseline;
+        int polls = 0;
+
+        await ClaudeConfigGate.WaitForQuiesceAsync(
+            baseline,
+            () => { if (++polls == 2) current = baseline.AddSeconds(1); return current; },
+            () => clock.Now,
+            clock.Delay,
+            cap: TimeSpan.FromMilliseconds(2000),
+            quietFor: TimeSpan.FromMilliseconds(250),
+            pollMs: 50);
+
+        // Write seen on poll 2 (~100ms), then 250ms of quiet -> well under the 2000ms cap.
+        Assert.True(clock.TotalWaitedMs < 2000,
+            $"expected an early return, waited {clock.TotalWaitedMs}ms");
+        Assert.True(clock.TotalWaitedMs >= 250,
+            $"must observe the full quiet period, waited only {clock.TotalWaitedMs}ms");
+    }
+
+    [Fact]
+    public async Task Wait_NoWriteEverObserved_WaitsTheFullCap()
+    {
+        // Deliberate: a machine where the file can't be watched must be no worse off
+        // than the old fixed delay, never faster-and-racy.
+        var clock = new Clock();
+        var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await ClaudeConfigGate.WaitForQuiesceAsync(
+            baseline,
+            () => baseline,
+            () => clock.Now,
+            clock.Delay,
+            cap: TimeSpan.FromMilliseconds(2000),
+            quietFor: TimeSpan.FromMilliseconds(250),
+            pollMs: 50);
+
+        Assert.True(clock.TotalWaitedMs >= 2000,
+            $"expected the full cap, waited {clock.TotalWaitedMs}ms");
+    }
+
+    [Fact]
+    public async Task Wait_FileKeepsChanging_StillStopsAtTheCap()
+    {
+        // A pathological writer must not extend shutdown/startup indefinitely.
+        var clock = new Clock();
+        var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        int n = 0;
+
+        await ClaudeConfigGate.WaitForQuiesceAsync(
+            baseline,
+            () => baseline.AddMilliseconds(++n * 10),   // never settles
+            () => clock.Now,
+            clock.Delay,
+            cap: TimeSpan.FromMilliseconds(1000),
+            quietFor: TimeSpan.FromMilliseconds(250),
+            pollMs: 50);
+
+        Assert.InRange(clock.TotalWaitedMs, 1000, 1100);
+    }
+
+    [Fact]
+    public async Task Wait_FileAppearsFromNothing_CountsAsAWrite()
+    {
+        // First-ever run: no config file at baseline, Claude creates one.
+        var clock = new Clock();
+        DateTime? current = null;
+        int polls = 0;
+
+        await ClaudeConfigGate.WaitForQuiesceAsync(
+            baseline: null,
+            () => { if (++polls == 2) current = clock.Now; return current; },
+            () => clock.Now,
+            clock.Delay,
+            cap: TimeSpan.FromMilliseconds(2000),
+            quietFor: TimeSpan.FromMilliseconds(250),
+            pollMs: 50);
+
+        Assert.True(clock.TotalWaitedMs < 2000,
+            $"creation should count as a write, waited {clock.TotalWaitedMs}ms");
+    }
+
+    [Fact]
+    public async Task Wait_ZeroCap_ReturnsImmediately()
+    {
+        // Mirrors the existing `staggerMs > 0` opt-out.
+        var clock = new Clock();
+
+        await ClaudeConfigGate.WaitForQuiesceAsync(
+            null, () => null, () => clock.Now, clock.Delay,
+            cap: TimeSpan.Zero, quietFor: TimeSpan.FromMilliseconds(250));
+
+        Assert.Empty(clock.Waits);
+    }
+}


### PR DESCRIPTION
Partially addresses #82.

## The cost

Restoring N consecutive Claude sessions slept `ClaudeLaunchStaggerMs` (default **2000ms**) between each. Nineteen gaps across twenty sessions is **38 seconds of pure `Task.Delay`** before any work happens. Shutdown paid up to another **1s per session** *after* already waiting for the process to exit.

## Why the delay can't just be deleted

It protects something real: the Claude CLI rewrites its config on startup, and two `claude.exe` doing it at once can lose each other's updates.

That isn't theoretical. The machine this was developed on has two orphaned temp files left by racing writers:

```
.claude.json.tmp.11360.fffb3231d0f5   Aug 12 00:14
.claude.json.tmp.44412.b20f9774f802   Aug 12 00:14
```

Same minute, two different pids.

## The change

`ClaudeConfigGate` watches the config file's last-write time and returns once it has changed and then stayed quiet for 250ms — **capped at the existing stagger value**, so the worst case is exactly what it is today. Typical cost becomes a few hundred milliseconds instead of a flat 2000.

Two deliberate choices:

- **No write observed → wait the full cap.** A machine where the file can't be watched is no worse off than before, rather than faster and racy.
- **Baseline captured before the launch whose write we're waiting on.** A fast write would otherwise land before the first poll and read as "never written".

## A targeting bug this exposed

The config sits at `%USERPROFILE%\.claude.json` by default — but `CLAUDE_CONFIG_DIR` relocates it **inside** that directory. That's a different *layout*, not just a different root, so it isn't `ResolveClaudeHome` plus a filename.

This machine has the env var set, and its `~/.claude.json` hasn't been touched since **12 June** while the real file is written continuously. Watching the wrong one would mean always hitting the cap and silently losing the whole optimisation.

## Shutdown

Same gate applied to the post-exit pause, which was a flat sleep the issue itself flagged as belt-and-braces guesswork after the process-handle wait.

## Tests

9 new, driving the state machine on a fake clock: early return on write-then-quiet, full cap when no write is seen, cap honoured when the file never settles, file-creation counting as a write, the zero-cap opt-out, and all three config-path resolution cases.

| Check | Result |
|---|---|
| Unit tests | **278/278** |
| App + Tests build | 0 errors, 0 warnings |

## Not addressed here

#82 also covers the sequential `LaunchSessionAsync` itself (WebView2 creation + navigation per session), and the 10s-per-session shutdown cap with no overall budget. Both are real and untouched — this PR only removes the fixed sleeping, which was the part that could be quantified without measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be