### PR TITLE
fix(terminal): don't let mouse movement steal focus or repaint every pane

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -1672,21 +1672,33 @@ public partial class MainWindow : Window
                 // would no longer match the sidebar ring.
                 var vm = _vm.Sessions.FirstOrDefault(s => s.Id == id);
                 string accentHex = vm?.AccentColor ?? (ui.terminalWrapper.Tag as string ?? "#89b4fa");
-                try
-                {
-                    var accent = (Color)ColorConverter.ConvertFromString(accentHex);
-                    ui.terminalWrapper.BorderBrush = new SolidColorBrush(accent);
-                }
-                catch
-                {
-                    ui.terminalWrapper.BorderBrush = new SolidColorBrush(Color.FromRgb(0x89, 0xb4, 0xfa));
-                }
+                Color accent;
+                try { accent = (Color)ColorConverter.ConvertFromString(accentHex); }
+                catch { accent = Color.FromRgb(0x89, 0xb4, 0xfa); }
+                SetBorderColor(ui.terminalWrapper, accent);
             }
             else
             {
-                ui.terminalWrapper.BorderBrush = Brushes.Transparent;
+                SetBorderColor(ui.terminalWrapper, Colors.Transparent);
             }
         }
+    }
+
+    /// <summary>
+    /// Assigns a border colour only when it actually differs.
+    ///
+    /// This used to allocate a fresh SolidColorBrush and reassign BorderBrush on every
+    /// pane on every call, so each invocation dirtied all of them and WPF repainted the
+    /// lot. Harmless at one call per session switch; very visible as flicker when
+    /// something calls it rapidly — which a bug briefly did on every mouse move.
+    /// Idempotent now, so a stray caller costs nothing visible.
+    /// </summary>
+    private static void SetBorderColor(Border border, Color color)
+    {
+        if (border.BorderBrush is SolidColorBrush current && current.Color == color) return;
+        var brush = new SolidColorBrush(color);
+        brush.Freeze();   // frozen brushes skip change-tracking and are cheaper to render
+        border.BorderBrush = brush;
     }
 
     // ── Sidebar quick-menu (right-click on empty sidebar / tab / placeholder area) ─

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -55,7 +55,22 @@ public sealed class TerminalBridge : IDisposable
     private long _lastOutputTickMs;
 
     public event Action<string>? RawOutputReceived;
+
+    /// <summary>
+    /// Any input travelling to the PTY — keystrokes, pastes, and mouse reports.
+    /// Used for "the user interacted with this session" (alert clearing).
+    /// </summary>
     public event Action? UserInput;
+
+    /// <summary>
+    /// Input that was not a mouse report, i.e. an actual keystroke or paste.
+    ///
+    /// Separate from <see cref="UserInput"/> because xterm's onData carries mouse
+    /// reports too whenever the running app enables mouse tracking (Claude Code does).
+    /// Anything that changes UI state off the back of input must use this one, or
+    /// merely moving the mouse across a pane drives it.
+    /// </summary>
+    public event Action? KeyboardInput;
 
     /// <summary>
     /// Fires when the user presses a keyboard accelerator (Ctrl-combo, F-key, etc.)
@@ -288,6 +303,21 @@ public sealed class TerminalBridge : IDisposable
         _coalescer.Append(rawData);
     }
 
+    /// <summary>
+    /// True when <paramref name="data"/> is a terminal mouse report rather than typed
+    /// input. Covers the two encodings xterm.js emits:
+    ///   SGR (modern, the default for xterm.js)  ESC [ &lt; btn ; col ; row (M|m)
+    ///   X10 / normal (legacy)                   ESC [ M btn col row
+    ///
+    /// Motion events fire continuously while the pointer moves over a pane with mouse
+    /// tracking on, so anything driving UI state off input has to skip these.
+    /// </summary>
+    internal static bool IsMouseReport(string data) =>
+        data.Length >= 3
+        && data[0] == '\x1b'
+        && data[1] == '['
+        && (data[2] == '<' || data[2] == 'M');
+
     private void OnAcceleratorKeyPressed(object? sender, WpfKeyEventArgs e)
     {
         AcceleratorKeyPressed?.Invoke(this, e);
@@ -321,6 +351,7 @@ public sealed class TerminalBridge : IDisposable
                         _pty?.Write(data);
                     }
                     UserInput?.Invoke();
+                    if (!IsMouseReport(data)) KeyboardInput?.Invoke();
                     break;
                 }
 

--- a/src/CodeShellManager/ViewModels/MainViewModel.cs
+++ b/src/CodeShellManager/ViewModels/MainViewModel.cs
@@ -284,24 +284,21 @@ public partial class MainViewModel : ObservableObject
             // there), so it must stay cheap. NotifyUserInteracted already fires AlertCleared
             // unconditionally, whose handler below raises AlertCount — so this deliberately
             // does not raise it a second time (issue #70).
-            vm.Bridge.UserInput += () =>
+            // Typing into a pane makes it the active session, so its output flushes at
+            // foreground dispatcher priority (#70) instead of behind every other pane.
+            //
+            // MUST NOT fire on mouse movement. terminal-init.js forwards xterm's onData,
+            // and onData carries mouse reports as well as keystrokes whenever the running
+            // app enables mouse tracking — which Claude Code does. Promoting on those
+            // turned this into hover-to-focus and repainted every pane's border on every
+            // mouse move. Hence the mouse-report filter rather than promoting on any input.
+            vm.Bridge.KeyboardInput += () =>
             {
-                // Typing into a pane makes it the active session.
-                //
-                // Without this, ActiveSession only moved when the user clicked a SIDEBAR
-                // row — there is no focus handler on the WebView2. So in a multi-pane
-                // layout, clicking straight into a pane and typing left ActiveSession on
-                // whatever the sidebar last selected, which left this bridge's
-                // IsForeground false, which made its output flush at Background
-                // dispatcher priority. The pane you are typing in rendered its own echo
-                // behind every other session's output — the #70 priority split working
-                // exactly as designed, against the wrong session.
-                //
-                // Guarded on reference equality: this runs per keystroke, and the assign
-                // fans out to UpdateActiveTerminalHighlight over every session.
+                // Guarded on reference equality: runs per keystroke, and the assign fans
+                // out to UpdateActiveTerminalHighlight across every session.
                 if (!ReferenceEquals(ActiveSession, vm)) ActiveSession = vm;
-                vm.AlertDetector?.NotifyUserInteracted();
             };
+            vm.Bridge.UserInput += () => vm.AlertDetector?.NotifyUserInteracted();
         }
 
         if (vm.AlertDetector != null)

--- a/tests/CodeShellManager.Tests/MouseReportTests.cs
+++ b/tests/CodeShellManager.Tests/MouseReportTests.cs
@@ -1,0 +1,51 @@
+using CodeShellManager.Terminal;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// xterm's onData carries mouse reports alongside keystrokes whenever the running app
+/// enables mouse tracking (Claude Code does). Anything that changes UI state off input
+/// has to tell them apart, or moving the pointer across a pane drives the UI —
+/// which is exactly what shipped briefly as hover-to-focus plus border flicker.
+/// </summary>
+public class MouseReportTests
+{
+    [Theory]
+    // SGR encoding — what xterm.js emits by default. Move, press, release.
+    [InlineData("\x1b[<35;80;24M")]
+    [InlineData("\x1b[<0;10;5M")]
+    [InlineData("\x1b[<0;10;5m")]
+    [InlineData("\x1b[<64;1;1M")]      // wheel up
+    // X10 / normal encoding — legacy apps.
+    [InlineData("\x1b[M\x20\x21\x21")]
+    public void IsMouseReport_MouseSequences_AreDetected(string data)
+    {
+        Assert.True(TerminalBridge.IsMouseReport(data));
+    }
+
+    [Theory]
+    [InlineData("a")]
+    [InlineData("hello")]
+    [InlineData("\r")]
+    [InlineData("\x7f")]               // backspace
+    [InlineData("\x03")]               // Ctrl+C
+    [InlineData("\x1b")]               // bare Esc
+    [InlineData("\x1b[A")]             // Up arrow
+    [InlineData("\x1b[B")]             // Down arrow
+    [InlineData("\x1b[3~")]            // Delete
+    [InlineData("\x1b[I")]             // focus-in report — not a mouse move
+    [InlineData("\x1b[200~pasted\x1b[201~")]   // bracketed paste
+    [InlineData("")]
+    public void IsMouseReport_KeyboardInput_IsNotMistakenForMouse(string data)
+    {
+        Assert.False(TerminalBridge.IsMouseReport(data));
+    }
+
+    [Fact]
+    public void IsMouseReport_ShortStrings_DoNotOverrun()
+    {
+        Assert.False(TerminalBridge.IsMouseReport("\x1b"));
+        Assert.False(TerminalBridge.IsMouseReport("\x1b["));
+    }
+}


### PR DESCRIPTION
Regression from #93, caught in testing before it shipped — **v0.6.0 predates it, so no release is affected.**

## What broke

#93 promoted a pane to `ActiveSession` on `TerminalBridge.UserInput`, on the assumption that input meant typing. It doesn't.

`terminal-init.js` forwards xterm's `term.onData(...)`, and **`onData` carries mouse reports as well as keystrokes** whenever the running app enables mouse tracking — which Claude Code does. So moving the pointer across a pane promoted it, turning the fix into hover-to-focus.

Reported as: *"it changes focus whenever I just move the mouse over another terminal — and that is problematic. Also, just moving the mouse makes all terminals flicker a lot."*

## Fix 1 — split the signal

- `UserInput` still fires for everything and keeps driving alert clearing, which is what it was always for.
- New `KeyboardInput` fires only when the data isn't a mouse report. Promotion listens to that.

Clicking, `Ctrl+Tab` and typing all still promote. Hovering does nothing.

`IsMouseReport` covers both encodings xterm emits — SGR (`ESC[<btn;col;row` + `M`/`m`) and legacy X10 (`ESC[Mbtn...`). The tests pin the **negative** cases deliberately: arrow keys, `Delete`, bracketed paste and focus-in reports all start with `ESC[` too, and a looser check would have swallowed the arrow keys.

## Fix 2 — the flicker was a separate, pre-existing defect

`UpdateActiveTerminalHighlight` allocated a fresh `SolidColorBrush` and reassigned `BorderBrush` on **every** pane on **every** call — so each invocation dirtied all of them and WPF repainted the lot.

Invisible at one call per session switch. A visible storm once something called it on every mouse move. My bug exposed it rather than caused it, which is why reverting #93 alone wouldn't have been enough.

Now idempotent (skips when the colour already matches) with frozen brushes, so a stray rapid caller costs nothing visible.

## Verification

| Check | Result |
|---|---|
| Unit tests | **296/296** (18 new) |
| App + Tests build | 0 errors, 0 warnings |
| Hover behaviour | confirmed correct by the reporter against a test build |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be