### PR TITLE
fix(pty): always fire Exited so a failed DuplicateHandle can't stall shutdown

### DIFF
--- a/src/CodeShellManager/Terminal/PseudoTerminal.cs
+++ b/src/CodeShellManager/Terminal/PseudoTerminal.cs
@@ -362,26 +362,43 @@ public sealed class PseudoTerminal : IPseudoTerminal
 
     private async Task MonitorExitAsync()
     {
-        // Duplicate _hProcess so Dispose() can close the original without racing the wait.
-        // Closing a handle that another thread is waiting on is Win32 UB — the wait may
-        // return prematurely and we'd fire Exited before the child actually exits.
-        if (!DuplicateHandle(GetCurrentProcess(), _hProcess, GetCurrentProcess(),
-                out IntPtr waitHandle, 0, false, DUPLICATE_SAME_ACCESS))
-        {
-            Log($"DuplicateHandle failed: {Marshal.GetLastWin32Error()}");
-            return;
-        }
+        // Exited must fire on EVERY path, exactly once (issue #91).
+        //
+        // MainWindow.DisposeAndWaitForExitAsync waits on this event with a 10s timeout,
+        // and the shutdown loop is sequential. A path that returns without firing costs
+        // the full 10s for that session, every time, on top of every other session's.
+        // The early return below used to do exactly that.
         try
         {
-            await Task.Run(() => WaitForSingleObject(waitHandle, 0xFFFFFFFF));
-            if (GetExitCodeProcess(waitHandle, out uint code))
-                ExitCode = unchecked((int)code);
+            // Duplicate _hProcess so Dispose() can close the original without racing the
+            // wait. Closing a handle another thread is waiting on is Win32 UB — the wait
+            // may return prematurely and we'd fire Exited before the child actually exits.
+            if (!DuplicateHandle(GetCurrentProcess(), _hProcess, GetCurrentProcess(),
+                    out IntPtr waitHandle, 0, false, DUPLICATE_SAME_ACCESS))
+            {
+                // Can't observe the real exit, so ExitCode stays null and the caller
+                // treats it as unknown — but it must not be left waiting on an event
+                // that will never arrive.
+                Log($"DuplicateHandle failed: {Marshal.GetLastWin32Error()} — " +
+                    "firing Exited without an exit code so shutdown doesn't stall");
+                return;
+            }
+
+            try
+            {
+                await Task.Run(() => WaitForSingleObject(waitHandle, 0xFFFFFFFF));
+                if (GetExitCodeProcess(waitHandle, out uint code))
+                    ExitCode = unchecked((int)code);
+            }
+            finally
+            {
+                CloseHandle(waitHandle);
+            }
         }
         finally
         {
-            CloseHandle(waitHandle);
+            Exited?.Invoke();
         }
-        Exited?.Invoke();
     }
 
     public void Dispose()


### PR DESCRIPTION
Closes #91.

## The bug

`MonitorExitAsync` returned early when `DuplicateHandle` failed — **before** `Exited?.Invoke()`. Every other path fired it; that one silently didn't.

`MainWindow.DisposeAndWaitForExitAsync` waits on `Exited` with a 10s timeout, and the Claude shutdown loop is sequential. So a session that never fires costs the full 10 seconds, on top of every other session's. Bounded rather than hanging — which is why it's low severity — but it lands on exactly the symptom #82 is about.

## Fix

Wrapped the body so `Exited?.Invoke()` runs in a `finally`. Every path now fires it exactly once.

On the failure path `ExitCode` stays null, so the caller reads the exit as *unknown* rather than as a fabricated success.

## On testing

**No unit test, deliberately.** `MonitorExitAsync` is private, and the failure is a Win32 call that can't be induced without mocking P/Invoke — which would test the mock, not the code. The `finally` makes the guarantee structural rather than depending on every future return path remembering to fire.

Flagging it rather than leaving the gap to be assumed covered.

| Check | Result |
|---|---|
| Unit tests | **296/296** |
| App + Tests build | 0 errors, 0 warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be