### PR TITLE
fix(startup): run the Claude config gate off the UI thread

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -5358,13 +5358,24 @@ public partial class MainWindow : Window
     /// between consecutive Claude launches (issue #82).
     /// </summary>
     private Task WaitForClaudeConfigQuiesceAsync(DateTime? baseline, int capMs) =>
-        ClaudeConfigGate.WaitForQuiesceAsync(
+        // Task.Run is the actual fix for the overshoot, not just tidiness.
+        //
+        // This is awaited from the restore loop, which runs on the UI thread. Left there,
+        // every Task.Delay continuation queues behind whatever the dispatcher is doing —
+        // and during restore that's creating a WebView2 per session. A "50ms" poll then
+        // takes seconds, and the file-time reads are synchronous I/O on the same thread.
+        // Measured on a real restore before this change: gate=22953ms against a 2000ms
+        // cap, and 63s of a 70s restore spent in here — far worse than the flat 2s stagger
+        // this replaced.
+        //
+        // On the thread pool the timer continuations are prompt and the cap holds.
+        Task.Run(() => ClaudeConfigGate.WaitForQuiesceAsync(
             baseline,
             () => ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath),
             () => DateTime.UtcNow,
             Task.Delay,
             TimeSpan.FromMilliseconds(capMs),
-            ClaudeConfigGate.DefaultQuietFor);
+            ClaudeConfigGate.DefaultQuietFor));
 
     private static async Task DisposeAndWaitForExitAsync(SessionViewModel vm, int timeoutMs)
     {

--- a/src/CodeShellManager/Properties/launchSettings.json
+++ b/src/CodeShellManager/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "CodeShellManager": {
       "commandName": "Project",
-      "commandLineArgs": "--clean",
       "hotReloadEnabled": false
     }
   }

--- a/src/CodeShellManager/Services/ClaudeConfigGate.cs
+++ b/src/CodeShellManager/Services/ClaudeConfigGate.cs
@@ -84,7 +84,19 @@ internal static class ClaudeConfigGate
 
         while (utcNow() - start < cap)
         {
-            await delayAsync(pollMs);
+            // Never sleep past the deadline: ask for at most the remaining budget.
+            int remaining = (int)(cap - (utcNow() - start)).TotalMilliseconds;
+            if (remaining <= 0) return;
+
+            await delayAsync(Math.Min(pollMs, remaining)).ConfigureAwait(false);
+
+            // Belt-and-braces. Note this does NOT explain the measured overshoot
+            // (gate=22953ms against a 2000ms cap): the top-of-loop check already caught
+            // that on the next pass, so it was ONE starved continuation, not a missed
+            // deadline. The fix for that is running this off the UI thread — see
+            // MainWindow.WaitForClaudeConfigQuiesceAsync. Kept because it costs nothing
+            // and stops a late delay from being followed by yet another poll.
+            if (utcNow() - start >= cap) return;
 
             DateTime? current = lastWriteUtc();
             if (current != seen)

--- a/tests/CodeShellManager.Tests/ClaudeConfigGateTests.cs
+++ b/tests/CodeShellManager.Tests/ClaudeConfigGateTests.cs
@@ -137,6 +137,27 @@ public class ClaudeConfigGateTests
     }
 
     [Fact]
+    public async Task Wait_NeverSleepsPastTheDeadline()
+    {
+        // Each individual sleep is clamped to the remaining budget, so the wait can't
+        // overshoot by a whole poll interval at the tail either.
+        var clock = new Clock();
+        var baseline = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await ClaudeConfigGate.WaitForQuiesceAsync(
+            baseline,
+            () => baseline,
+            () => clock.Now,
+            clock.Delay,
+            cap: TimeSpan.FromMilliseconds(175),   // deliberately not a multiple of pollMs
+            quietFor: TimeSpan.FromMilliseconds(250),
+            pollMs: 50);
+
+        Assert.True(clock.TotalWaitedMs <= 175,
+            $"slept {clock.TotalWaitedMs}ms against a 175ms cap");
+    }
+
+    [Fact]
     public async Task Wait_ZeroCap_ReturnsImmediately()
     {
         // Mirrors the existing `staggerMs > 0` opt-out.


### PR DESCRIPTION
Fixes a regression I introduced in #96 — caught by the instrumentation from #101, on a real restore rather than by reasoning.

## The measurement

11 sessions, 70.5s total restore:

```
gate  sum: 62948ms      <- 89% of restore time
launch sum:  7548ms
```

Individual gates of **14296ms**, **22953ms**, **11090ms** — against a **2000ms** cap. One is 11× over.

So #96 made restore substantially *worse* than the flat 2s stagger it replaced, which is the opposite of what it claimed. On the machine I originally measured, launch dominated and the gate looked fine; the failure only shows on a machine loaded enough for it to matter.

## Cause

`WaitForQuiesceAsync` is awaited from the restore loop, which runs on the **UI thread**. Every `Task.Delay` continuation therefore queues behind whatever the dispatcher is doing — during restore, creating a WebView2 per session. A "50ms" poll takes seconds, and the file-time reads are synchronous I/O on that same thread.

On the thread pool the timer continuations are prompt and the cap holds.

## Being precise about what actually fixed it

The post-delay deadline check in this PR is **belt-and-braces and does not explain the measurement.** The old loop's top-of-loop check already exited after a late delay, so `gate=22953ms` was **one starved continuation**, not a missed deadline.

I initially wrote a test asserting the opposite. It passed against the old code too — so it proved nothing, and it's gone rather than left in to look like coverage. `Task.Run` is the fix.

What *is* genuinely new and tested: each sleep is now clamped to the remaining budget, so the tail can't overshoot by a whole poll interval. `Wait_NeverSleepsPastTheDeadline` fails against the old loop.

| Check | Result |
|---|---|
| Unit tests | **312/312** |
| App + Tests build | 0 errors, 0 warnings |

## Worth knowing

If this doesn't bring restore back under the old flat-2s baseline on a loaded machine, the adaptive gate isn't earning its complexity and #96 should simply be reverted. The next `RESTORE` lines in `crash.log` will say — `gate=` should now sit near 300ms, and never exceed ~2000ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be