### PR TITLE
fix(terminal): make clicking a pane activate it, from the page side

### DIFF
--- a/src/CodeShellManager/Assets/terminal-init.js
+++ b/src/CodeShellManager/Assets/terminal-init.js
@@ -58,6 +58,28 @@
     window.chrome.webview.postMessage(JSON.stringify({ type: 'userkey' }));
   });
 
+  // ── "the user clicked into this pane" signal ───────────────────────────────
+  // This MUST come from here rather than from WPF. WebView2 is an HwndHost — a
+  // native child window — and WPF routed mouse events (tunnelling Preview* ones
+  // included) do not fire for input that lands on hosted native content. A
+  // PreviewMouseLeftButtonDown on the host Border therefore only ever fires for
+  // the 2px ring around the terminal, never for a click in the terminal itself,
+  // so clicking a pane never made it the active session.
+  //
+  // fit() here as well: the grid rebuild that used to run on every activation
+  // incidentally forced a layout pass and hence a re-fit. That rebuild is now
+  // skipped when nothing visible changes, so re-fit on interaction has to be
+  // explicit — otherwise xterm's column count can drift from what the PTY was
+  // told, and redraws land a character off.
+  var lastActivate = 0;
+  document.addEventListener('mousedown', function () {
+    var now = Date.now();
+    if (now - lastActivate < 300) return;
+    lastActivate = now;
+    try { fitAddon.fit(); } catch (e) {}
+    window.chrome.webview.postMessage(JSON.stringify({ type: 'activate' }));
+  }, { capture: true });
+
   // ── Resize notification ────────────────────────────────────────────────────
   term.onResize(({ cols, rows }) => {
     window.chrome.webview.postMessage(JSON.stringify({ type: 'resize', cols, rows }));

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -3753,13 +3753,11 @@ public partial class MainWindow : Window
             Tag = accent
         };
 
-        // Clicking anywhere in a pane makes that session active. Tunnelling (Preview)
-        // because the WebView2 swallows the bubbling event before it reaches us, and
-        // Handled is deliberately NOT set so the click still lands in the terminal.
-        //
-        // Without this, ActiveSession only followed sidebar clicks, so a pane clicked
-        // directly kept IsForeground=false and flushed its output at Background
-        // dispatcher priority — its own echo queued behind every other session's.
+        // Fires only for the thin ring/chrome AROUND the terminal — WebView2 is an
+        // HwndHost, so a click on the terminal itself never reaches WPF as a routed
+        // event. The terminal case is handled by TerminalBridge.PaneActivated, posted
+        // from the page. Kept because clicking the border should still activate, and
+        // Handled is deliberately unset so the click still passes through.
         activeRing.PreviewMouseLeftButtonDown += (_, _) =>
         {
             if (!ReferenceEquals(_vm.ActiveSession, vm)) _vm.ActiveSession = vm;

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -79,6 +79,15 @@ public sealed class TerminalBridge : IDisposable
     public event Action? KeyboardInput;
 
     /// <summary>
+    /// The user clicked into this pane. Posted from the page's <c>mousedown</c>, because
+    /// WebView2 is an <c>HwndHost</c>: mouse input landing on hosted native content never
+    /// raises WPF routed events, so a <c>PreviewMouseLeftButtonDown</c> on the host Border
+    /// only fires for the thin ring around the terminal — never for the terminal itself.
+    /// That is why clicking a pane did not make it the active session.
+    /// </summary>
+    public event Action? PaneActivated;
+
+    /// <summary>
     /// Fires when the user presses a keyboard accelerator (Ctrl-combo, F-key, etc.)
     /// while the WebView2 has focus. Subscribers set <c>e.Handled = true</c> to prevent
     /// the key from also reaching xterm.js. The WPF WebView2 wrapper forwards
@@ -349,6 +358,13 @@ public sealed class TerminalBridge : IDisposable
                 // See terminal-init.js for why onData can't be used for this.
                 case "userkey":
                     KeyboardInput?.Invoke();
+                    break;
+
+                // Posted from the page on mousedown. WebView2 is an HwndHost, so a click
+                // in the terminal never reaches WPF as a routed event — this is the only
+                // way the host learns the user clicked into this pane.
+                case "activate":
+                    PaneActivated?.Invoke();
                     break;
 
                 case "resize":

--- a/src/CodeShellManager/ViewModels/MainViewModel.cs
+++ b/src/CodeShellManager/ViewModels/MainViewModel.cs
@@ -292,12 +292,17 @@ public partial class MainViewModel : ObservableObject
             // app enables mouse tracking — which Claude Code does. Promoting on those
             // turned this into hover-to-focus and repainted every pane's border on every
             // mouse move. Hence the mouse-report filter rather than promoting on any input.
-            vm.Bridge.KeyboardInput += () =>
+            // Guarded on reference equality: these run per keystroke / per click, and the
+            // assign fans out to UpdateActiveTerminalHighlight across every session.
+            void Promote()
             {
-                // Guarded on reference equality: runs per keystroke, and the assign fans
-                // out to UpdateActiveTerminalHighlight across every session.
                 if (!ReferenceEquals(ActiveSession, vm)) ActiveSession = vm;
-            };
+            }
+
+            vm.Bridge.KeyboardInput += Promote;
+            // Clicking into a pane must promote it too. This can only come from the page —
+            // see TerminalBridge.PaneActivated for why WPF never sees the click.
+            vm.Bridge.PaneActivated += Promote;
             vm.Bridge.UserInput += () => vm.AlertDetector?.NotifyUserInteracted();
         }
 


### PR DESCRIPTION
Clicking a terminal has **never** made it the active session — including after #93, which was supposed to fix exactly that.

## Why

#93 added a `PreviewMouseLeftButtonDown` handler on the pane's host `Border`. But **WebView2 is an `HwndHost`**: mouse input landing on hosted native content does not raise WPF routed events at all, tunnelling ones included. That handler only ever fired for the ~2px ring *around* the terminal, never for a click in it.

So #93 worked for the sidebar path, and — after #106 — for typing. Never for clicking. Reported as *"still won't switch tabs in the left menu when I click and put focus on another window."*

## Fix

The click can only be observed from inside the page. `terminal-init.js` now posts an `activate` message on `mousedown` (throttled to 300ms, since promotion is idempotent), `TerminalBridge` raises `PaneActivated`, and `MainViewModel` promotes on that and on `KeyboardInput` through one shared handler.

## The character offset, same PR

Also reported: typing started one character *into* Claude's placeholder, leaving a stray leading `T` from `Try "how do I log an error?"`.

The page-side handler now also calls `fitAddon.fit()`. The grid rebuild that used to run on every activation incidentally forced a layout pass and therefore a re-fit; **#105 skips that rebuild when nothing visible changes**, so the re-fit has to be explicit now. Without it xterm's column count drifts from what the PTY was told and redraws land a column off.

That's the second thing #105 turned out to be silently propping up — worth weighing whether it earns its keep (see below).

## Also

Corrected the WPF-side comment, which claimed that handler covered clicks in the pane. It never did.

| Check | Result |
|---|---|
| Unit tests | **312/312** |
| App + Tests build | 0 errors, 0 warnings |
| `activate` present in published `Assets/terminal-init.js` | ✅ |

## Worth discussing: is #105 still worth it?

Its benefit — avoiding WebView2 reattachment on focus change — was **never measured**. The 89%-of-restore cost turned out to be the config gate (#107), not the grid rebuild. Meanwhile it has now been implicated in two regressions: the lost re-fit above, and it required a non-obvious signature + version counter to avoid breaking pane paging and restarted-session rendering.

Reverting it is defensible. Not doing that here, since this PR fixes the user-visible symptom either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be