### PR TITLE
perf(pty): wait for process exit without holding a thread-pool thread

### DIFF
--- a/src/CodeShellManager/Terminal/PseudoTerminal.cs
+++ b/src/CodeShellManager/Terminal/PseudoTerminal.cs
@@ -360,6 +360,37 @@ public sealed class PseudoTerminal : IPseudoTerminal
         catch (Exception ex) { Log($"ReadLoop error: {ex.Message}"); }
     }
 
+    /// <summary>
+    /// Awaits a Win32 handle becoming signalled without occupying a thread while it waits.
+    ///
+    /// <see cref="ThreadPool.RegisterWaitForSingleObject"/> registers the handle with the
+    /// OS wait infrastructure; the callback runs on a pool thread only once it signals.
+    /// The registration is unregistered from inside the callback, which is the documented
+    /// way to release it exactly once for a one-shot wait.
+    /// </summary>
+    private static Task WaitForHandleAsync(IntPtr handle)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var safe = new SafeWaitHandle(handle, ownsHandle: false);   // caller closes the handle
+        var waitHandle = new ManualResetEvent(false) { SafeWaitHandle = safe };
+
+        RegisteredWaitHandle? registration = null;
+        registration = ThreadPool.RegisterWaitForSingleObject(
+            waitHandle,
+            (_, _) =>
+            {
+                // Unregister first so the entry is released even if a continuation throws.
+                registration?.Unregister(null);
+                waitHandle.Dispose();
+                tcs.TrySetResult();
+            },
+            state: null,
+            millisecondsTimeOutInterval: Timeout.Infinite,
+            executeOnlyOnce: true);
+
+        return tcs.Task;
+    }
+
     private async Task MonitorExitAsync()
     {
         // Exited must fire on EVERY path, exactly once (issue #91).
@@ -386,7 +417,21 @@ public sealed class PseudoTerminal : IPseudoTerminal
 
             try
             {
-                await Task.Run(() => WaitForSingleObject(waitHandle, 0xFFFFFFFF));
+                // Wait WITHOUT holding a thread.
+                //
+                // This used to be `await Task.Run(() => WaitForSingleObject(h, INFINITE))`,
+                // which parks one thread-pool thread per live PTY for the whole lifetime of
+                // the session — plus one per run-command PTY. With ~25 sessions restoring,
+                // that is ~25 permanently blocked pool threads, and the pool only injects
+                // replacements at roughly one per second. Everything else queued behind it.
+                //
+                // Measured consequence: the Claude launch gate, itself moved onto the pool
+                // in #107, waited up to 23998ms against a 2000ms cap — not because the gate
+                // was slow but because it could not get a thread. 81s of a 135s restore.
+                //
+                // RegisterWaitForSingleObject hands the wait to the OS and calls back on a
+                // pool thread only once the handle signals, so an idle PTY costs nothing.
+                await WaitForHandleAsync(waitHandle).ConfigureAwait(false);
                 if (GetExitCodeProcess(waitHandle, out uint code))
                     ExitCode = unchecked((int)code);
             }


### PR DESCRIPTION
The reason #107 didn't fix the launch gate.

## What the log showed

A real 25-session restore, **after** #107:

```
gate sum: 81,379ms of a 135s restore     max: 23,998ms   (cap: 2000ms)
```

Most gates were fine — `303`, `401`, `464`, `512`, `769`, `798ms`. **Three** blew out: `18149`, `23142`, `23998ms`.

Usually-fast, occasionally-catastrophic is thread starvation, not a slow gate.

## Cause

`MonitorExitAsync` did:

```csharp
await Task.Run(() => WaitForSingleObject(waitHandle, 0xFFFFFFFF));   // INFINITE
```

That parks **one thread-pool thread per live PTY for the entire lifetime of the session** — plus one per run-command PTY. With ~25 sessions restoring, ~25 pool threads are permanently blocked, and the pool injects replacements at roughly one per second.

#107 moved the gate off the saturated UI thread and onto the pool. That fixed the common case and put it behind *this* queue for the unlucky ones — which is why the fix looked partially effective rather than wrong.

This is also the likely reason shutdown differs so sharply between machines running identical code: `3 waited / 14 force-disposed / 27002ms` on a 41-session machine against `10 waited / 0 / 7662ms` on a smaller one.

## Fix

`ThreadPool.RegisterWaitForSingleObject` hands the wait to the OS and only consumes a pool thread once the handle signals, so an idle PTY costs nothing.

Details worth noting for review:
- The registration unregisters from **inside its own callback** — the documented one-shot pattern.
- The duplicated handle is still closed by `MonitorExitAsync`'s `finally`, so the `SafeWaitHandle` is constructed with `ownsHandle: false` to avoid a double close.
- The `Exited`-always-fires guarantee from #91 is untouched.

| Check | Result |
|---|---|
| Unit tests | **312/312** |
| App + Tests build | 0 errors, 0 warnings |

## What to look for after this

The `RESTORE` lines. If `gate=` now stays under ~2000ms across the board, the adaptive gate is finally behaving. If restore is still dominated by it, #96 isn't earning its complexity and I'd revert it for the predictable flat 2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be