### PR TITLE
revert(startup): flat Claude launch stagger; keep the adaptive gate at shutdown

### DIFF
--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -277,10 +277,6 @@ public partial class MainWindow : Window
             // so simultaneous boots can corrupt the user's profile.
             int staggerMs = _vm.Settings.ClaudeLaunchStaggerMs;
             bool lastWasClaude = false;
-            // Last-write time of Claude's config captured just before the previous
-            // Claude launch, so the gate below can tell whether that launch has
-            // finished writing yet. See ClaudeConfigGate (issue #82).
-            DateTime? prevClaudeCfgBaseline = null;
             // WebView2 user-data folder access-denied is a common shared-failure
             // when another instance is running. Batch these so the user gets one
             // actionable dialog at the end instead of N "Restore Error" popups.
@@ -293,19 +289,25 @@ public partial class MainWindow : Window
                 if (s.IsDormant) continue;
                 bool isClaude = ClaudeSessionService.IsClaudeCommand(s.Command);
 
-                // Wait for the PREVIOUS Claude to finish rewriting its config rather
-                // than sleeping a flat staggerMs. Same protection, but it costs what it
-                // actually takes instead of the worst case every time — 19 consecutive
-                // Claude sessions used to mean 38s of pure sleep. Capped at staggerMs,
-                // so this can never be slower than the old behaviour.
+                // Flat stagger, deliberately. The adaptive config-watching gate from #96
+                // could not hold its own 2000ms cap on this path and was reverted here;
+                // measured across three runs on a 10-session machine it produced gates of
+                // 12574ms, 22953ms and 31378ms. Two follow-up fixes (#107 off the UI
+                // thread, #110 off the blocked-thread-per-PTY) roughly halved it but never
+                // bounded it.
+                //
+                // What it bought when it did work was ~1.2s per session, and a third of
+                // the samples hit the cap anyway — i.e. behaved exactly like this line
+                // with more machinery. Predictable beats occasionally-clever on a path
+                // the user waits through at every launch.
+                //
+                // The gate is still used at SHUTDOWN, where the machine is quiet and it
+                // measures a consistent ~304ms against this same flat 1000ms — see
+                // OnClosing. Different contention, different answer.
                 long gateStart = restoreClock.ElapsedMilliseconds;
                 if (isClaude && lastWasClaude && staggerMs > 0)
-                    await WaitForClaudeConfigQuiesceAsync(prevClaudeCfgBaseline, staggerMs);
+                    await Task.Delay(staggerMs);
                 long gateMs = restoreClock.ElapsedMilliseconds - gateStart;
-
-                // Baseline BEFORE launching — a fast write would otherwise land before
-                // the first poll and read as "never written".
-                if (isClaude) prevClaudeCfgBaseline = ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath);
 
                 long launchStart = restoreClock.ElapsedMilliseconds;
                 try { await LaunchSessionAsync(s, restoring: true); }
@@ -587,16 +589,13 @@ public partial class MainWindow : Window
         int staggerMs = _vm.Settings.ClaudeLaunchStaggerMs;
         string anchorId = primary.Id;
         bool lastWasClaude = ClaudeSessionService.IsClaudeCommand(primary.Command);
-        DateTime? prevClaudeCfgBaseline = lastWasClaude
-            ? ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath) : null;
         foreach (var path in additionalPaths)
         {
             if (!System.IO.Directory.Exists(path)) continue;
             bool isClaude = ClaudeSessionService.IsClaudeCommand(primary.Command);
-            // Adaptive gate rather than a flat sleep — see the restore loop in OnLoaded.
-            if (isClaude && lastWasClaude && staggerMs > 0)
-                await WaitForClaudeConfigQuiesceAsync(prevClaudeCfgBaseline, staggerMs);
-            if (isClaude) prevClaudeCfgBaseline = ClaudeConfigGate.LastWriteUtcOrNull(_claudeConfigPath);
+            // Flat stagger — see the restore loop in OnLoaded for why the adaptive gate
+            // was reverted on launch paths.
+            if (isClaude && lastWasClaude && staggerMs > 0) await Task.Delay(staggerMs);
             var sibling = _sessionManager.CreateSession(
                 System.IO.Path.GetFileName(path.TrimEnd('/', '\\')) ?? primary.Command,
                 path,


### PR DESCRIPTION
Reverting part of my own #96. Three attempts to make the adaptive gate hold its cap on the launch path have failed.

## The measurements

Same 10-session machine, three consecutive builds:

| build | gate sum | max | cap |
|---|---|---|---|
| pre-#107 | ~61s | 22,953ms | 2000ms |
| **#107** (off the UI thread) | ~62s | 31,378ms | 2000ms |
| **#110** (off the blocked thread) | ~34s | 12,574ms | 2000ms |

Each fix was real — #110 in particular halved it — but neither **bounded** it.

## What it was actually buying

Across all 30 samples:

- **~1/3 pinned at ~2000ms** (`2003, 2012, 2017, 2018, 2023, 1970, 1999, 2317`) — no write observed, waited the full cap. Identical to a flat delay, with more machinery.
- **~1/3 genuine wins** (`0, 0, 354, 603, 713, 752, 808, 823, 1211`) — roughly 1.2s saved each.
- **The rest 5–31s.**

A mechanism whose best case saves ~1.2s and whose worst case costs 12–31s doesn't belong on a path the user waits through at every launch. Predictable beats occasionally-clever here.

Both launch paths go back to `Task.Delay(staggerMs)`.

## Kept at shutdown, because there the data says the opposite

`cfgSettle` measures a consistent **~304ms against the flat 1000ms** — every run, both machines. The machine is quiet at shutdown, so polling is reliable. Same mechanism, different contention, different answer. Both call sites now carry comments explaining which is which, so neither gets "unified" later.

## #110 stays regardless

Parking a thread-pool thread per PTY is wrong on its own merits, and it halved this. This PR doesn't depend on it and touches different files.

## Net effect

For a 10-Claude-session restore: a bounded **~20s** of stagger instead of ~34s with 12-second outliers. Restore becomes predictable, and what's left is `launch=` — the WebView2 cost, which is the genuine remaining half of #82.

| Check | Result |
|---|---|
| Unit tests | **312/312** |
| App + Tests build | 0 errors, 0 warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be