### PR TITLE
fix(chocolatey): serve the icon from a CDN and check for WebView2

### DIFF
--- a/.chocolatey/codeshellmanager.nuspec
+++ b/.chocolatey/codeshellmanager.nuspec
@@ -8,7 +8,10 @@
     <title>CodeShellManager</title>
     <authors>umage.ai</authors>
     <projectUrl>https://umage.ai/products/code-shell-manager/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/umage-ai/CodeShellManager/ad0ea186aefc00c4d4494f04d15f5dd5492c774e/src/CodeShellManager/Assets/app.png</iconUrl>
+    <!-- Must be a CDN — raw.githubusercontent.com is not permitted by Chocolatey moderation.
+         Pinned to a commit rather than a branch so the icon can never change under a
+         published package. -->
+    <iconUrl>https://cdn.jsdelivr.net/gh/umage-ai/CodeShellManager@ad0ea186aefc00c4d4494f04d15f5dd5492c774e/src/CodeShellManager/Assets/app.png</iconUrl>
     <copyright>Copyright (c) 2025 umage.ai</copyright>
     <licenseUrl>https://github.com/umage-ai/CodeShellManager/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/.chocolatey/tools/chocolateyinstall.ps1
+++ b/.chocolatey/tools/chocolateyinstall.ps1
@@ -10,6 +10,42 @@ $checksum64  = '__CHECKSUM64__'
 
 $logPath = "$env:TEMP\$packageName.$env:chocolateyPackageVersion.MsiInstall.log"
 
+# CodeShellManager renders its terminals in WebView2, so the Evergreen Runtime is a hard
+# requirement at run time. It ships with Windows 11 and with recent Windows 10, so this
+# WARNS rather than fails: a missing runtime is worth telling the user about, but a
+# detection miss must not block an install that would have worked.
+#
+# Deliberately a check and not a <dependency> on webview2-runtime — that would pull and
+# install the runtime on every machine, including the majority that already have it.
+$wv2Clients = @(
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+  'HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+  'HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+)
+$wv2Version = $null
+foreach ($key in $wv2Clients) {
+  try {
+    $pv = (Get-ItemProperty -Path $key -Name pv -ErrorAction Stop).pv
+    if ($pv -and $pv -ne '0.0.0.0') { $wv2Version = $pv; break }
+  } catch { }
+}
+
+if ($wv2Version) {
+  Write-Host "Microsoft Edge WebView2 Runtime detected (version $wv2Version)."
+} else {
+  Write-Warning @'
+Microsoft Edge WebView2 Runtime was not detected.
+
+CodeShellManager renders its terminals in WebView2 and will not display them without it.
+It is included with Windows 11 and recent Windows 10 builds; if terminals appear blank
+after install, get the Evergreen Runtime from:
+
+    https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+
+or run:  choco install webview2-runtime
+'@
+}
+
 $packageArgs = @{
   packageName    = $packageName
   unzipLocation  = $toolsDir


### PR DESCRIPTION
Moderator feedback on the 0.5.0 submission. The install side was passed as clean — official GitHub MSI with a SHA256, silent `/qn`, proper uninstall, clean scan. One required change, one suggestion.

## Required — iconUrl must be a CDN

`raw.githubusercontent.com` isn't permitted. Switched to the jsdelivr URL the moderator supplied, still **pinned to commit `ad0ea186`** rather than a branch, so the icon can't change underneath a published package.

Verified rather than assumed:

```
HTTP/1.1 200 OK
Content-Type: image/png
Content-Length: 2530     <- byte-identical to src/CodeShellManager/Assets/app.png
```

## Suggested — a WebView2 dependency or check

The description mentioned WebView2 but nothing checked for it. Added a registry probe for the Evergreen Runtime that **warns rather than fails**.

The reasoning: WebView2 ships with Windows 11 and recent Windows 10, so a detection miss must not block an install that would have worked. But a genuinely missing runtime means **blank terminals**, which is worth naming at install time rather than leaving the user to discover it.

**Deliberately a check, not a `<dependency>` on `webview2-runtime`** — a dependency would pull and install the runtime on every machine, including the majority that already have it.

Probes `WOW6432Node` first, which is where it actually resolved when tested on a real machine (`152.0.4191.53`); `HKLM` and `HKCU` are fallbacks.

## Verified

- `chocolateyinstall.ps1` parses (PowerShell AST parser)
- `codeshellmanager.nuspec` is well-formed XML
- The detection logic run against this machine finds the runtime on the first key
- CDN URL resolves and matches the repo file byte-for-byte

## Two things this does not solve

1. **The moderator asked to resubmit the same 0.5.0.** The workflow templates `__VERSION__`, so dispatching `chocolatey.yml` with `tag=v0.5.0` rebuilds that package with the corrected nuspec.
2. **`CHOCO_API_KEY` still returns 403.** That failed on the v0.6.0 attempt on 19 Aug and was never resolved, so any push will fail regardless of this fix. Worth checking the key at https://community.chocolatey.org/account before dispatching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be