### PR TITLE
fix(terminal): re-fit once the font has loaded, not on a timing guess

### DIFF
--- a/src/CodeShellManager/Assets/terminal-init.js
+++ b/src/CodeShellManager/Assets/terminal-init.js
@@ -108,6 +108,16 @@
         if (opts.padding       !== undefined) document.getElementById('terminal').style.padding = opts.padding;
         if (opts.retro         !== undefined) document.body.classList.toggle('retro', !!opts.retro);
         fitAddon.fit();
+        // A profile override can switch fontFamily/fontSize to a face that isn't loaded
+        // yet, so the fit above measures the wrong metrics for the same reason the
+        // initial one can. Re-fit once the new face is ready.
+        if (opts.fontFamily !== undefined || opts.fontSize !== undefined) {
+          if (document.fonts && document.fonts.ready) {
+            document.fonts.ready.then(function () {
+              try { fitAddon.fit(); } catch (e) {}
+            });
+          }
+        }
       }
       else if (msg.type === 'dropOverlayClear') overlay.classList.remove('active');
       else if (msg.type === 'setBootState') {
@@ -260,5 +270,26 @@
   // Re-fit after a short delay so xterm picks up the real dimensions once visible.
   setTimeout(() => { try { fitAddon.fit(); term.focus(); } catch {} }, 50);
   setTimeout(() => { try { fitAddon.fit(); } catch {} }, 250);
+
+  // Re-fit once the font has actually loaded.
+  //
+  // xterm derives its column count from the MEASURED advance width of the font. The
+  // first fit() runs immediately after term.open(); if Cascadia Code hasn't loaded
+  // yet, xterm measures the fallback's metrics, computes the wrong cols, and reports
+  // a width to the PTY that doesn't match what is drawn — text then wraps and
+  // overlaps mid-line.
+  //
+  // The ResizeObserver above cannot correct this: the ELEMENT size never changed,
+  // only the glyph metrics, so no resize fires. It stays wrong until something else
+  // forces a fit, which is why switching layouts appeared to "fix" it.
+  //
+  // The two timeouts above are guesses at "fonts are probably ready by now" and are
+  // easily too early during a heavy restore with many WebView2s initialising. They
+  // stay as a fallback for the 0x0 case; this is the real signal.
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(function () {
+      try { fitAddon.fit(); } catch (e) {}
+    });
+  }
 
   term.focus();


### PR DESCRIPTION
Reported as initial rendering looking wrong — text wrapping and running together mid-line — which corrected itself as soon as the view changed.

## Cause

xterm derives its column count from the **measured advance width** of the font. The first `fit()` runs immediately after `term.open()`. If Cascadia Code hasn't loaded yet, xterm measures the *fallback's* metrics, computes the wrong `cols`, and reports a width to the PTY that doesn't match what's drawn.

The `ResizeObserver` cannot correct this: the **element** size never changed, only the glyph metrics, so no resize event fires. It stays wrong until something else forces a fit — which is exactly why switching layouts appeared to fix it.

The two existing `setTimeout` fits (50ms, 250ms) are guesses at *"fonts are probably ready by now"*, and are easily too early during a restore with many WebView2s initialising at once.

## Fix

`document.fonts.ready` is the actual signal. The timeouts stay, since they also cover the separate 0×0-container case, but they're no longer load-bearing for font metrics.

Same treatment where a profile override changes `fontFamily`/`fontSize` — that can switch to a face that isn't loaded either, and the `fit()` there had the identical problem.

## Worth noting for the #105 discussion

This got *worse* recently rather than appearing from nowhere. #105 stopped rebuilding the grid on activation, and that rebuild used to force an incidental re-fit that masked the mismeasurement.

That's now **three** things #105 turned out to be propping up — the lost re-fit on click (#108), this one, and the signature/version-counter machinery it needed to avoid breaking pane paging and restarted-session rendering. Its own benefit was never measured, and the restore cost turned out to be elsewhere. I still think reverting it is the cleaner call, and I'd rather raise that a third time than keep patching around it.

| Check | Result |
|---|---|
| Unit tests | **312/312** |
| App + Tests build | 0 errors, 0 warnings |

## How to verify

Restore a full session set and look at the panes *before* touching anything. Text should be correctly wrapped from the first paint, with no mid-line overlap and no need to switch layouts to correct it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be