### PR TITLE
feat: shell integration channel (OSC 9001) for color, git, title — rebased (supersedes #19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,7 @@ ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.
 
 | Key | Effect |
 |---|---|
-| `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. |
+| `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. 8-digit values use alpha-last (`#rrggbbaa`); CSM converts to WPF's `#aarrggbb` internally. |
 | `git-branch` | Set `SessionViewModel.GitBranch` directly, bypassing `GitService`. |
 | `git-dirty` | `1`/`true` → dirty-marker shown; `0`/anything else → clean. |
 | `title` | Renames the session (calls `vm.Rename`). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ PTY (ConPTY) → PseudoTerminal → TerminalBridge → WebView2 (xterm.js)
 | `CursorShapeMapper` | WT `cursorShape` → xterm.js `cursorStyle` (+ optional forced blink) |
 | `PaddingParser` | WT `padding` shorthand (1/2/4 comma ints) → CSS `Npx` shorthand |
 | `CommandLineSplitter` | Helper — quote-aware split of a Windows commandline into `(exe, args)` |
+| `ShellIntegrationPayload` | WPF-free validation for the OSC 9001 channel: hex-colour check + `#rrggbbaa`→`#aarrggbb`, dirty-flag parse, title/branch sanitising (control chars stripped, 80-char cap). See "Shell Integration (OSC 9001)" |
 
 ## Project Structure
 
@@ -286,11 +287,19 @@ ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.
 | `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. 8-digit values use alpha-last (`#rrggbbaa`); CSM converts to WPF's `#aarrggbb` internally. |
 | `git-branch` | Set `SessionViewModel.GitBranch` directly, bypassing `GitService`. |
 | `git-dirty` | `1`/`true` → dirty-marker shown; `0`/anything else → clean. |
-| `title` | Renames the session (calls `vm.Rename`). |
+| `title` | Renames the session (calls `vm.Rename`). Capped at `ShellIntegrationPayload.MaxTitleLength` (80), control chars stripped; empty-after-cleanup is ignored. |
 
-Unknown keys are ignored. Multiple keys can be sent in a single sequence.
+Unknown keys are ignored. Multiple keys can be sent in a single sequence. Values cannot contain `;` (the field separator, no escaping) — documented as a limitation rather than solved.
 
-**Pipeline:** `terminal-init.js` registers an OSC handler via `term.parser.registerOscHandler(9001, …)` (requires `allowProposedApi: true`, already set). It posts `{type: "shellIntegration", fields: {…}}` to WPF. `TerminalBridge` parses it and raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and calls `vm.ApplyShellIntegration(fields)` on the dispatcher, then `SaveStateAsync` so changes persist.
+**Every value is untrusted.** It comes from whatever is printing to the terminal — a remote host, a `cat` of some file, a hook — and `color`/`title` end up in `state.json`. All validation lives in the WPF-free `Services/ShellIntegrationPayload` (`TryNormalizeColor`, `ParseDirty`, `SanitizeTitle`, `SanitizeBranch`) so it is unit-tested (`ShellIntegrationPayloadTests`); `SessionViewModel.ApplyShellIntegration` only applies what that class accepts.
+
+**Git poller stand-down.** Once a session has received `git-branch` or `git-dirty`, `RefreshGitInfoAsync` stops touching `GitBranch`/`GitIsDirty` (`_gitOverriddenByOsc`) — otherwise the local CWD's state would clobber the pushed value every 10s. The flag is per-session-lifetime, not persisted, and `ReloadGitInfoAsync` (folder edit) resets it, since the pushed info described the old folder.
+
+**Colour is sticky, so it is resettable.** OSC 9001 is the only writer of `ShellSession.ColorOverride` and the override survives sleep/wake and restart. The sidebar right-click menu shows **Reset accent color** (→ `vm.ClearColorOverride()`) whenever an override exists.
+
+**AlertDetector must strip both OSC terminators.** Its ANSI regex originally matched only BEL-terminated OSC; every example in `docs/shell-integration.md` uses `ESC \`, which either leaked the payload into prompt matching or lazily swallowed real output up to the next BEL. It now mirrors `OutputIndexer.AnsiPattern` — keep the two in step (`AlertDetectorStripAnsiTests`).
+
+**Pipeline:** `terminal-init.js` registers an OSC handler via `term.parser.registerOscHandler(9001, …)` (requires `allowProposedApi: true`, already set). It posts `{type: "shellIntegration", fields: {…}}` to WPF. `TerminalBridge` parses it and raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and calls `vm.ApplyShellIntegration(fields)` on the dispatcher, then `MainViewModel.SaveStateDebounced()` (500ms idle coalescing — a prompt hook fires on every prompt, and a `state.json` write per emission would be silly). Repainting the stripe and ring is **not** done here: the existing `AccentColor` `PropertyChanged` subscriptions in `BuildSidebarItem` / `BuildTerminalWrapper` already handle it, exactly as they do when `RepoRoot` lands.
 
 The OSC handler returns `true` so xterm consumes the sequence and it doesn't render.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,29 @@ The snapshot model is `Models/RecentlyClosedEntry.cs` — a separate POCO from `
 
 FTS5 scrollback retention is **out of scope** for v1 — restored sessions start with an empty xterm buffer.
 
+## Shell Integration (OSC 9001)
+
+Programs running inside a terminal can push session state up to CSM by emitting a custom OSC sequence — useful for SSH overlays (e.g. `nexus`) where CSM cannot inspect the remote repo locally.
+
+**Wire format:** `ESC ] 9001 ; key=value ; key=value … ST`
+
+ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.
+
+**Recognised keys:**
+
+| Key | Effect |
+|---|---|
+| `color` | Override the session accent (`#rrggbb` / `#rgb` / `#rrggbbaa`). Repaints sidebar stripe + active ring. |
+| `git-branch` | Set `SessionViewModel.GitBranch` directly, bypassing `GitService`. |
+| `git-dirty` | `1`/`true` → dirty-marker shown; `0`/anything else → clean. |
+| `title` | Renames the session (calls `vm.Rename`). |
+
+Unknown keys are ignored. Multiple keys can be sent in a single sequence.
+
+**Pipeline:** `terminal-init.js` registers an OSC handler via `term.parser.registerOscHandler(9001, …)` (requires `allowProposedApi: true`, already set). It posts `{type: "shellIntegration", fields: {…}}` to WPF. `TerminalBridge` parses it and raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and calls `vm.ApplyShellIntegration(fields)` on the dispatcher, then `SaveStateAsync` so changes persist.
+
+The OSC handler returns `true` so xterm consumes the sequence and it doesn't render.
+
 ## Sleep / Wake (Dormant Sessions)
 
 Sessions can be put to sleep instead of closed — the PTY is torn down but the `ShellSession` is kept in `state.json` (`IsDormant = true`) so it can be relaunched from the sidebar later. Useful when you have many long-running projects but only need a few live at once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,8 @@ FTS5 scrollback retention is **out of scope** for v1 — restored sessions start
 
 Programs running inside a terminal can push session state up to CSM by emitting a custom OSC sequence — useful for SSH overlays (e.g. `nexus`) where CSM cannot inspect the remote repo locally.
 
+> **Integrator-facing reference:** [`docs/shell-integration.md`](docs/shell-integration.md) (wire format + bash/PowerShell/Python/Node/Rust/Go snippets). The notes below are CSM-internal.
+
 **Wire format:** `ESC ] 9001 ; key=value ; key=value … ST`
 
 ST may be `BEL` (`\x07`) or `ESC \\` — xterm.js accepts both.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Built with WPF + [xterm.js](https://xtermjs.org/) + Windows ConPTY for full pseu
 - **Alert detection** — detects when Claude is waiting for input or tool approval; green/orange dot indicators
 - **Git status** — shows branch and dirty state in the sidebar per session
 - **Session rename** — double-click any session name or click ✏ to rename inline
+- **Shell integration** — programs running in a session can push their accent color, git branch / dirty state, and tab title to CSM via OSC 9001 (handy for SSH overlays). See [`docs/shell-integration.md`](docs/shell-integration.md).
 - **Auto-resume** — automatically resumes the last Claude Code session when restoring on startup (`--resume <id>`); toggleable in Settings
 - **SSH remote sessions** — connect to remote hosts using your existing SSH config; sessions persist across restarts
 - **Windows Terminal profile import** — opt-in import of profiles from Windows Terminal's `settings.json`; pick a profile in the New Session dialog to stamp its font, color scheme, cursor and padding onto the new terminal

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -1,0 +1,161 @@
+# CodeShellManager Shell Integration
+
+Programs running inside a CodeShellManager terminal can push session state up to the host UI by emitting a custom OSC (Operating System Command) escape sequence. This is the recommended way for tools like SSH overlays, REPLs, and TUI apps to keep CSM's accent color, git status, and tab title in sync with whatever the program actually represents — even when CSM cannot inspect that state locally.
+
+## Wire format
+
+```
+ESC ] 9001 ; key=value ; key=value … ST
+```
+
+- `ESC` is `\x1b` (`0o33`, `27`).
+- `9001` is the CSM-namespaced OSC identifier.
+- `ST` ("string terminator") is either `BEL` (`\x07`) or `ESC \` (`\x1b\x5c`). Both are accepted.
+- Keys and values are separated by `=`. Multiple fields are separated by `;`.
+- Whitespace around keys/values is trimmed.
+- Unknown keys are silently ignored — safe to emit forward-compatibly.
+- The whole sequence is consumed by xterm and never rendered.
+
+## Recognised keys
+
+| Key          | Value format            | Effect |
+|--------------|-------------------------|--------|
+| `color`      | `#rgb`, `#rrggbb`, `#rrggbbaa` | Override the session accent. Repaints the sidebar stripe and the active-pane ring immediately. |
+| `git-branch` | string                  | Set the branch label shown in the sidebar. Bypasses CSM's local `git` polling — useful for SSH/remote sessions. |
+| `git-dirty`  | `0`/`1` (or `false`/`true`) | Toggle the dirty marker (`*`) shown next to the branch. |
+| `title`      | string                  | Rename the session (same as double-clicking the sidebar entry). Persisted to `state.json`. |
+
+Multiple keys can be sent in a single sequence; CSM applies them atomically and saves state once.
+
+## Examples
+
+All examples below emit `color=#a6e3a1`, `git-branch=feat/foo`, `git-dirty=1`, `title=my-repo` in a single sequence. Adapt to your needs.
+
+### bash / zsh / sh
+
+```bash
+printf '\e]9001;color=#a6e3a1;git-branch=feat/foo;git-dirty=1;title=my-repo\e\\'
+```
+
+To refresh on every prompt, drop this into your shell init:
+
+```bash
+__csm_update() {
+  local branch dirty
+  branch=$(git symbolic-ref --short HEAD 2>/dev/null) || branch=""
+  [ -n "$(git status --porcelain 2>/dev/null)" ] && dirty=1 || dirty=0
+  printf '\e]9001;git-branch=%s;git-dirty=%s\e\\' "$branch" "$dirty"
+}
+PROMPT_COMMAND='__csm_update'    # bash
+# precmd_functions+=(__csm_update)  # zsh
+```
+
+### PowerShell
+
+```powershell
+$esc = [char]27
+"$esc]9001;color=#a6e3a1;git-branch=feat/foo;git-dirty=1;title=my-repo$esc\" | Write-Host -NoNewline
+```
+
+In a `prompt` function:
+
+```powershell
+function prompt {
+    $esc = [char]27
+    $branch = (git symbolic-ref --short HEAD 2>$null)
+    $dirty  = if ((git status --porcelain 2>$null)) { 1 } else { 0 }
+    Write-Host -NoNewline "$esc]9001;git-branch=$branch;git-dirty=$dirty$esc\"
+    "PS $($executionContext.SessionState.Path.CurrentLocation)> "
+}
+```
+
+### Python
+
+```python
+import sys
+
+def csm_update(**fields):
+    payload = ";".join(f"{k}={v}" for k, v in fields.items())
+    sys.stdout.write(f"\x1b]9001;{payload}\x1b\\")
+    sys.stdout.flush()
+
+csm_update(color="#a6e3a1", **{"git-branch": "feat/foo", "git-dirty": "1"}, title="my-repo")
+```
+
+### Node.js
+
+```js
+function csmUpdate(fields) {
+  const payload = Object.entries(fields).map(([k, v]) => `${k}=${v}`).join(';');
+  process.stdout.write(`\x1b]9001;${payload}\x1b\\`);
+}
+
+csmUpdate({ color: '#a6e3a1', 'git-branch': 'feat/foo', 'git-dirty': '1', title: 'my-repo' });
+```
+
+### Rust
+
+```rust
+fn csm_update(fields: &[(&str, &str)]) {
+    let payload: String = fields.iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(";");
+    print!("\x1b]9001;{payload}\x1b\\");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+}
+
+csm_update(&[
+    ("color", "#a6e3a1"),
+    ("git-branch", "feat/foo"),
+    ("git-dirty", "1"),
+    ("title", "my-repo"),
+]);
+```
+
+### Go
+
+```go
+package main
+
+import (
+    "fmt"
+    "strings"
+)
+
+func csmUpdate(fields map[string]string) {
+    parts := make([]string, 0, len(fields))
+    for k, v := range fields {
+        parts = append(parts, k+"="+v)
+    }
+    fmt.Printf("\x1b]9001;%s\x1b\\", strings.Join(parts, ";"))
+}
+```
+
+## Patterns
+
+**Update on every prompt.** Cheap, predictable, and handles `cd` / branch switches automatically. Use the shell snippets above.
+
+**Update on relevant events only.** If a prompt-hook is too coarse — e.g. inside a long-running TUI like `nexus` — call your update function whenever your internal state changes (new repo selected, dirty state changes, branch checked out, etc.).
+
+**Reset on exit.** If your program owns the session's accent for its lifetime, restore the default before exiting:
+
+```bash
+# Clearing color sends the empty string, which CSM treats as "use the default hash"
+# (only true if you've also chosen to clear ColorOverride; currently CSM keeps the
+# last value. To restore the original hash, leave the color key out entirely.)
+```
+
+In the current build, an emitted `color=` is sticky and persists in `state.json` across restarts. If you want it to revert when your program exits, emit nothing extra — but if a different program later runs in the same session, it will inherit your color until it sets its own.
+
+## Limitations
+
+- The protocol is one-way: CSM does not respond to OSC 9001 sequences with any data.
+- There's no acknowledgement that a sequence was parsed. Validate your output with the inspector if you want to be sure (DevTools is enabled in WebView2; press `F12` inside a terminal pane).
+- Color values must be valid CSS hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Named colors and `rgb()` syntax are rejected.
+- The terminating byte should be `BEL` or `ESC \`. xterm.js will eventually time out an unterminated OSC, but until then your text appears swallowed.
+
+## Pipeline (for CSM contributors)
+
+`terminal-init.js` registers the OSC handler via `term.parser.registerOscHandler(9001, …)`. The handler parses the payload, posts `{type: "shellIntegration", fields: {…}}` over the WebView2 message channel, and returns `true` so xterm consumes the sequence. `TerminalBridge.OnWebMessageReceived` raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and dispatches to `SessionViewModel.ApplyShellIntegration(fields)`, then triggers `SaveStateAsync`. Color/title changes propagate through `INotifyPropertyChanged` to repaint the sidebar stripe and active ring; git fields update `GitBranch` / `GitIsDirty`.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -20,7 +20,7 @@ ESC ] 9001 ; key=value ; key=value … ST
 
 | Key          | Value format            | Effect |
 |--------------|-------------------------|--------|
-| `color`      | `#rgb`, `#rrggbb`, `#rrggbbaa` | Override the session accent. Repaints the sidebar stripe and the active-pane ring immediately. |
+| `color`      | `#rgb`, `#rrggbb`, `#rrggbbaa` | Override the session accent. Repaints the sidebar stripe and the active-pane ring immediately. 8-digit values use **alpha-last** (`#rrggbbaa`) — CSM converts them internally to WPF's `#aarrggbb` format. |
 | `git-branch` | string                  | Set the branch label shown in the sidebar. Bypasses CSM's local `git` polling — useful for SSH/remote sessions. |
 | `git-dirty`  | `0`/`1` (or `false`/`true`) | Toggle the dirty marker (`*`) shown next to the branch. |
 | `title`      | string                  | Rename the session (same as double-clicking the sidebar entry). Persisted to `state.json`. |

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -139,23 +139,17 @@ func csmUpdate(fields map[string]string) {
 
 **Update on relevant events only.** If a prompt-hook is too coarse — e.g. inside a long-running TUI like `nexus` — call your update function whenever your internal state changes (new repo selected, dirty state changes, branch checked out, etc.).
 
-**Reset on exit.** If your program owns the session's accent for its lifetime, restore the default before exiting:
-
-```bash
-# Clearing color sends the empty string, which CSM treats as "use the default hash"
-# (only true if you've also chosen to clear ColorOverride; currently CSM keeps the
-# last value. To restore the original hash, leave the color key out entirely.)
-```
-
-In the current build, an emitted `color=` is sticky and persists in `state.json` across restarts. If you want it to revert when your program exits, emit nothing extra — but if a different program later runs in the same session, it will inherit your color until it sets its own.
+**Color is sticky.** An emitted `color=` is stored on the session and persists across sleep/wake and app restarts. There is no wire-level "reset" — an empty or invalid value is ignored, not applied. If a different program later runs in the same session it inherits your color until it sets its own. The user can hand the color back to the default folder hash at any time with **Reset accent color** in the session's right-click menu.
 
 ## Limitations
 
 - The protocol is one-way: CSM does not respond to OSC 9001 sequences with any data.
 - There's no acknowledgement that a sequence was parsed. Validate your output with the inspector if you want to be sure (DevTools is enabled in WebView2; press `F12` inside a terminal pane).
 - Color values must be valid CSS hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Named colors and `rgb()` syntax are rejected.
+- **Values cannot contain `;`** — it is the field separator and there is no escaping. A `title=a;b` is read as `title=a` plus an unknown key `b`. `=` inside a value is fine (only the first `=` splits key from value).
+- **Titles are capped at 80 characters.** Control characters are stripped, whitespace is trimmed, and a title that is empty after that is ignored (the existing name is kept). The same stripping applies to `git-branch`.
 - The terminating byte should be `BEL` or `ESC \`. xterm.js will eventually time out an unterminated OSC, but until then your text appears swallowed.
 
 ## Pipeline (for CSM contributors)
 
-`terminal-init.js` registers the OSC handler via `term.parser.registerOscHandler(9001, …)`. The handler parses the payload, posts `{type: "shellIntegration", fields: {…}}` over the WebView2 message channel, and returns `true` so xterm consumes the sequence. `TerminalBridge.OnWebMessageReceived` raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and dispatches to `SessionViewModel.ApplyShellIntegration(fields)`, then triggers `SaveStateAsync`. Color/title changes propagate through `INotifyPropertyChanged` to repaint the sidebar stripe and active ring; git fields update `GitBranch` / `GitIsDirty`.
+`terminal-init.js` registers the OSC handler via `term.parser.registerOscHandler(9001, …)`. The handler parses the payload, posts `{type: "shellIntegration", fields: {…}}` over the WebView2 message channel, and returns `true` so xterm consumes the sequence. `TerminalBridge.OnWebMessageReceived` raises `ShellIntegrationReceived`. `MainWindow.LaunchSessionAsync` subscribes and dispatches to `SessionViewModel.ApplyShellIntegration(fields)`, then calls `MainViewModel.SaveStateDebounced` (one write per 500ms of quiet, so a chatty prompt hook can't hammer `state.json`). Validation and normalisation of the untrusted values — hex check, `#rrggbbaa` → `#aarrggbb`, title cap, control-character stripping — live in the WPF-free `Services/ShellIntegrationPayload`, which is what the unit tests target. Color/title changes propagate through `INotifyPropertyChanged` to repaint the sidebar stripe and active ring; git fields update `GitBranch` / `GitIsDirty`.

--- a/src/CodeShellManager/Assets/terminal-init.js
+++ b/src/CodeShellManager/Assets/terminal-init.js
@@ -32,6 +32,25 @@
   term.open(document.getElementById('terminal'));
   fitAddon.fit();
 
+  // ── Shell integration: OSC 9001;key=value;key=value;ST ─────────────────────
+  // A program inside the terminal can push session state up to CSM by emitting:
+  //   ESC ] 9001 ; color=#89b4fa ; git-branch=main ; git-dirty=1 ; title=foo  ST
+  // Recognised keys: color, git-branch, git-dirty (0/1), title.
+  // Returning true tells xterm we consumed the sequence so it isn't rendered.
+  term.parser.registerOscHandler(9001, data => {
+    try {
+      const fields = {};
+      for (const part of String(data).split(';')) {
+        const eq = part.indexOf('=');
+        if (eq > 0) fields[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+      }
+      window.chrome.webview.postMessage(JSON.stringify({
+        type: 'shellIntegration', fields
+      }));
+    } catch {}
+    return true;
+  });
+
   // ── Input → PTY ────────────────────────────────────────────────────────────
   function sendInput(data) {
     window.chrome.webview.postMessage(JSON.stringify({ type: 'input', data }));

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -1243,6 +1243,15 @@ public partial class MainWindow : Window
             bridge.RawOutputReceived += alertDetector.Feed;
         }
 
+        // Shell programs (e.g. an SSH overlay, a prompt hook, a Claude Code hook) push
+        // session state via OSC 9001. Apply it on the VM, then debounce-save so the
+        // accent/title persist without a state.json write per emission.
+        bridge.ShellIntegrationReceived += fields =>
+        {
+            Dispatcher.Invoke(() => vm.ApplyShellIntegration(fields));
+            _vm.SaveStateDebounced();
+        };
+
         string assetsDir = Path.Combine(AppContext.BaseDirectory, "Assets");
         bool wantTransparent = session.ProfileBackgroundOpacity is < 1.0;
         string htmlFile = wantTransparent ? "terminal-transparent.html" : "terminal.html";

--- a/src/CodeShellManager/MainWindow.xaml.cs
+++ b/src/CodeShellManager/MainWindow.xaml.cs
@@ -3037,6 +3037,20 @@ public partial class MainWindow : Window
             editItem.Click += async (_, _) => await EditSessionAsync(vm);
             menu.Items.Add(editItem);
 
+            // A program can recolour the session through OSC 9001 and the override persists
+            // across sleep/wake and restart. This is the only way to hand the colour back
+            // to the folder hash, so show it whenever an override exists.
+            if (vm.Session.ColorOverride is not null)
+            {
+                var resetColor = new System.Windows.Controls.MenuItem { Header = "Reset accent color" };
+                resetColor.Click += (_, _) =>
+                {
+                    vm.ClearColorOverride();
+                    _ = _vm.SaveStateAsync();
+                };
+                menu.Items.Add(resetColor);
+            }
+
             // Folder actions — only when there's a local working folder to open.
             if (!vm.Session.IsRemote && !string.IsNullOrEmpty(vm.Session.WorkingFolder))
             {

--- a/src/CodeShellManager/Services/AlertDetector.cs
+++ b/src/CodeShellManager/Services/AlertDetector.cs
@@ -75,11 +75,15 @@ public partial class AlertDetector : IDisposable
         }
     }
 
-    private static string StripAnsi(string raw) =>
+    internal static string StripAnsi(string raw) =>
         s_ansi.Replace(raw, "");
 
+    // OSC strings end in BEL (\x07) or ST (ESC \). Matching only BEL made an ST-terminated
+    // OSC either leak its payload into prompt matching or lazily swallow real output up to
+    // the next BEL. The `?` in the CSI class covers private-mode sequences (ESC[?25h).
+    // Same pattern as OutputIndexer.AnsiPattern — keep the two in step.
     private static readonly Regex s_ansi =
-        new(@"\x1B\[[0-9;]*[mGKHFJABCDsuhl]|\x1B\].*?\x07|\x1B[=>]", RegexOptions.Compiled);
+        new(@"\x1B\[[?0-9;]*[mGKHFJABCDsuhl]|\x1B\].*?(?:\x07|\x1B\\)|\x1B[=>]", RegexOptions.Compiled);
 
     // Matches Claude's "❯" prompt (U+276F), generic y/n prompts, and "?" questions
     private static readonly Regex s_prompt =

--- a/src/CodeShellManager/Services/ShellIntegrationPayload.cs
+++ b/src/CodeShellManager/Services/ShellIntegrationPayload.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Text;
+
+namespace CodeShellManager.Services;
+
+/// <summary>
+/// Validation and normalisation rules for the OSC 9001 shell-integration channel
+/// (see <c>docs/shell-integration.md</c>). Kept WPF-free so the rules are unit-testable.
+/// <para>
+/// Every value here is untrusted: it arrives from whatever is printing to the terminal —
+/// a remote host, a <c>cat</c> of an arbitrary file, a hook — and some of it ends up
+/// persisted in <c>state.json</c>. Reject what cannot be validated, trim and cap the rest.
+/// </para>
+/// </summary>
+public static class ShellIntegrationPayload
+{
+    /// <summary>Upper bound on a title pushed through OSC 9001. Long enough for any
+    /// sensible tab name; short enough that a runaway program can't bloat state.json
+    /// or the sidebar row.</summary>
+    public const int MaxTitleLength = 80;
+
+    /// <summary>
+    /// Accepts <c>#rgb</c>, <c>#rrggbb</c> and <c>#rrggbbaa</c>. Returns the string in the
+    /// form WPF's <c>ColorConverter</c> expects: 3- and 6-digit values unchanged, 8-digit
+    /// values reordered from the integrator convention (alpha last) to <c>#aarrggbb</c>
+    /// (alpha first). Anything else — named colours, <c>rgb()</c>, wrong length, non-hex —
+    /// is rejected.
+    /// </summary>
+    public static bool TryNormalizeColor(string? input, out string? wpfHex)
+    {
+        wpfHex = null;
+        if (string.IsNullOrEmpty(input) || input[0] != '#') return false;
+        if (input.Length != 4 && input.Length != 7 && input.Length != 9) return false;
+        for (int i = 1; i < input.Length; i++)
+            if (!Uri.IsHexDigit(input[i])) return false;
+
+        wpfHex = input.Length == 9
+            ? "#" + input[7..9] + input[1..7]
+            : input;
+        return true;
+    }
+
+    /// <summary>Only <c>1</c> and <c>true</c> (any case) mean dirty; everything else is clean.</summary>
+    public static bool ParseDirty(string? input)
+        => input == "1" || string.Equals(input, "true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Strips control characters, trims, and caps at <see cref="MaxTitleLength"/> without
+    /// splitting a surrogate pair. Returns <c>null</c> when nothing usable is left, so the
+    /// caller can leave the existing name alone rather than blank it.
+    /// </summary>
+    public static string? SanitizeTitle(string? input)
+    {
+        string? clean = StripControls(input);
+        if (clean is null) return null;
+        if (clean.Length <= MaxTitleLength) return clean;
+
+        int cut = MaxTitleLength;
+        if (char.IsHighSurrogate(clean[cut - 1])) cut--;
+        return clean[..cut].TrimEnd();
+    }
+
+    /// <summary>Strips control characters and trims. Returns <c>null</c> for an empty result,
+    /// which the caller treats as "no branch" (detached HEAD, not a repo).</summary>
+    public static string? SanitizeBranch(string? input) => StripControls(input);
+
+    private static string? StripControls(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        var sb = new StringBuilder(input.Length);
+        foreach (char c in input)
+            if (!char.IsControl(c)) sb.Append(c);
+        string result = sb.ToString().Trim();
+        return result.Length == 0 ? null : result;
+    }
+}

--- a/src/CodeShellManager/Terminal/TerminalBridge.cs
+++ b/src/CodeShellManager/Terminal/TerminalBridge.cs
@@ -88,6 +88,12 @@ public sealed class TerminalBridge : IDisposable
     public event Action? PaneActivated;
 
     /// <summary>
+    /// Fires when the running shell program emits OSC 9001 (CSM shell integration).
+    /// Carries the parsed key=value fields it included (color, git-branch, git-dirty, title, …).
+    /// </summary>
+    public event Action<System.Collections.Generic.IReadOnlyDictionary<string, string>>? ShellIntegrationReceived;
+
+    /// <summary>
     /// Fires when the user presses a keyboard accelerator (Ctrl-combo, F-key, etc.)
     /// while the WebView2 has focus. Subscribers set <c>e.Handled = true</c> to prevent
     /// the key from also reaching xterm.js. The WPF WebView2 wrapper forwards
@@ -398,6 +404,21 @@ public sealed class TerminalBridge : IDisposable
                     if (!string.IsNullOrEmpty(copy))
                         WpfApplication.Current?.Dispatcher.Invoke(() =>
                             WpfClipboard.SetText(copy));
+                    break;
+
+                case "shellIntegration":
+                    if (root.TryGetProperty("fields", out var fieldsEl)
+                        && fieldsEl.ValueKind == JsonValueKind.Object)
+                    {
+                        var dict = new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var prop in fieldsEl.EnumerateObject())
+                        {
+                            if (prop.Value.ValueKind == JsonValueKind.String)
+                                dict[prop.Name] = prop.Value.GetString() ?? "";
+                        }
+                        if (dict.Count > 0)
+                            ShellIntegrationReceived?.Invoke(dict);
+                    }
                     break;
 
                 case "filesDropped":

--- a/src/CodeShellManager/ViewModels/MainViewModel.cs
+++ b/src/CodeShellManager/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -20,11 +21,13 @@ public static class GroupFilter
     public const string AllKey = "__ALL__";
 }
 
-public partial class MainViewModel : ObservableObject
+public partial class MainViewModel : ObservableObject, IDisposable
 {
     private readonly SessionManager _sessionManager;
     private readonly StateService _stateService;
     private AppState _appState = new();
+    private System.Threading.Timer? _saveDebounceTimer;
+    private readonly object _timerLock = new();
 
     public ObservableCollection<SessionViewModel> Sessions { get; } = [];
 
@@ -246,6 +249,28 @@ public partial class MainViewModel : ObservableObject
         _sessionManager.PopulateState(_appState);
         _appState.LastLayout = Layout.ToString();
         await _stateService.SaveAsync(_appState);
+    }
+
+    /// <summary>
+    /// Debounced save for high-frequency events (e.g., OSC 9001 shell integration).
+    /// Coalesces multiple rapid calls into a single write after 500ms of idle.
+    /// Thread-safe: uses lock to prevent race conditions on timer replacement.
+    /// </summary>
+    public void SaveStateDebounced()
+    {
+        lock (_timerLock)
+        {
+            _saveDebounceTimer?.Dispose();
+            _saveDebounceTimer = new System.Threading.Timer(
+                _ => App.Current.Dispatcher.InvokeAsync(async () =>
+                {
+                    try { await SaveStateAsync(); }
+                    catch { /* non-critical: state persistence failures (disk full, permissions) */ }
+                }),
+                null,
+                500,
+                Timeout.Infinite);
+        }
     }
 
     public AppSettings Settings => _appState.Settings;
@@ -511,5 +536,14 @@ public partial class MainViewModel : ObservableObject
 
         if (seeded || layoutSwitched)
             _ = SaveStateAsync();
+    }
+
+    public void Dispose()
+    {
+        lock (_timerLock)
+        {
+            _saveDebounceTimer?.Dispose();
+            _saveDebounceTimer = null;
+        }
     }
 }

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -144,55 +144,43 @@ public partial class SessionViewModel : ObservableObject, IDisposable
     /// </summary>
     public void ApplyShellIntegration(System.Collections.Generic.IReadOnlyDictionary<string, string> fields)
     {
-        if (fields.TryGetValue("color", out var color) && IsValidHexColor(color))
+        // Every value is untrusted terminal output — validation lives in ShellIntegrationPayload.
+        if (fields.TryGetValue("color", out var color)
+            && ShellIntegrationPayload.TryNormalizeColor(color, out var wpfHex))
         {
-            // WPF ColorConverter.ConvertFromString interprets 8-digit hex as #AARRGGBB.
-            // Integrators emit #rrggbbaa (alpha last), so we reorder before storing.
-            Session.ColorOverride = ToWpfHexColor(color);
+            Session.ColorOverride = wpfHex;
             OnPropertyChanged(nameof(AccentColor));
         }
 
         if (fields.TryGetValue("git-branch", out var branch))
         {
-            GitBranch = string.IsNullOrWhiteSpace(branch) ? null : branch;
+            GitBranch = ShellIntegrationPayload.SanitizeBranch(branch);
             GitInfoLoaded = true;
             _gitOverriddenByOsc = true;
         }
 
         if (fields.TryGetValue("git-dirty", out var dirty))
         {
-            GitIsDirty = dirty == "1" || string.Equals(dirty, "true", StringComparison.OrdinalIgnoreCase);
+            GitIsDirty = ShellIntegrationPayload.ParseDirty(dirty);
             _gitOverriddenByOsc = true;
         }
 
-        if (fields.TryGetValue("title", out var title) && !string.IsNullOrWhiteSpace(title))
-            Rename(title.Trim());
-    }
-
-    private static bool IsValidHexColor(string s)
-    {
-        if (string.IsNullOrEmpty(s) || s[0] != '#') return false;
-        if (s.Length != 4 && s.Length != 7 && s.Length != 9) return false;
-        for (int i = 1; i < s.Length; i++)
-            if (!Uri.IsHexDigit(s[i])) return false;
-        return true;
+        if (fields.TryGetValue("title", out var title)
+            && ShellIntegrationPayload.SanitizeTitle(title) is { } cleanTitle)
+            Rename(cleanTitle);
     }
 
     /// <summary>
-    /// Converts an integrator-supplied hex color to WPF format.
-    /// <para>
-    /// 6-digit (<c>#rrggbb</c>) and 3-digit (<c>#rgb</c>) values are stored as-is.
-    /// 8-digit values use the integrator convention <c>#rrggbbaa</c> (alpha last),
-    /// but WPF's <see cref="System.Windows.Media.ColorConverter"/> expects <c>#AARRGGBB</c>
-    /// (alpha first), so we reorder to <c>#aarrggbb</c>.
-    /// </para>
+    /// Drops a <see cref="ShellSession.ColorOverride"/> so the accent falls back to the
+    /// hash-derived colour. OSC 9001 is currently the only writer of that field and it
+    /// persists across sleep/wake and restart, so without this a program that recoloured
+    /// a session once would own its colour forever.
     /// </summary>
-    private static string ToWpfHexColor(string s)
+    public void ClearColorOverride()
     {
-        // Only 8-digit (#rrggbbaa) needs reordering; 3- and 6-digit are fine as-is.
-        if (s.Length == 9)
-            return "#" + s[7..9] + s[1..7];
-        return s;
+        if (Session.ColorOverride is null) return;
+        Session.ColorOverride = null;
+        OnPropertyChanged(nameof(AccentColor));
     }
 
     public void RaiseAlert(string message, AlertType alertType = AlertType.InputRequired)
@@ -239,6 +227,10 @@ public partial class SessionViewModel : ObservableObject, IDisposable
         GitIsDirty = false;
         GitInfoLoaded = false;
         HasWorktreeSiblings = false;
+        // The user just pointed this session at a different folder, so whatever program
+        // pushed git info via OSC 9001 was describing the old one. Let the local poller
+        // back in until a program re-declares itself.
+        _gitOverriddenByOsc = false;
         return RefreshGitInfoAsync();
     }
 

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -129,7 +129,7 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Applies a CSM shell-integration payload (OSC 9001) emitted by the running program.
-    /// Recognised keys: <c>color</c> (#rrggbb), <c>git-branch</c>, <c>git-dirty</c> (0/1),
+    /// Recognised keys: <c>color</c> (#rrggbb / #aarrggbb), <c>git-branch</c>, <c>git-dirty</c> (0/1),
     /// <c>title</c>. Unknown keys are ignored. Useful for SSH overlays whose remote
     /// state CSM cannot inspect locally.
     /// </summary>
@@ -137,7 +137,9 @@ public partial class SessionViewModel : ObservableObject, IDisposable
     {
         if (fields.TryGetValue("color", out var color) && IsValidHexColor(color))
         {
-            Session.ColorOverride = color;
+            // WPF ColorConverter.ConvertFromString interprets 8-digit hex as #AARRGGBB.
+            // Integrators emit #rrggbbaa (alpha last), so we reorder before storing.
+            Session.ColorOverride = ToWpfHexColor(color);
             OnPropertyChanged(nameof(AccentColor));
         }
 
@@ -161,6 +163,23 @@ public partial class SessionViewModel : ObservableObject, IDisposable
         for (int i = 1; i < s.Length; i++)
             if (!Uri.IsHexDigit(s[i])) return false;
         return true;
+    }
+
+    /// <summary>
+    /// Converts an integrator-supplied hex color to WPF format.
+    /// <para>
+    /// 6-digit (<c>#rrggbb</c>) and 3-digit (<c>#rgb</c>) values are stored as-is.
+    /// 8-digit values use the integrator convention <c>#rrggbbaa</c> (alpha last),
+    /// but WPF's <see cref="System.Windows.Media.ColorConverter"/> expects <c>#AARRGGBB</c>
+    /// (alpha first), so we reorder to <c>#aarrggbb</c>.
+    /// </para>
+    /// </summary>
+    private static string ToWpfHexColor(string s)
+    {
+        // Only 8-digit (#rrggbbaa) needs reordering; 3- and 6-digit are fine as-is.
+        if (s.Length == 9)
+            return "#" + s[7..9] + s[1..7];
+        return s;
     }
 
     public void RaiseAlert(string message, AlertType alertType = AlertType.InputRequired)

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -127,6 +127,42 @@ public partial class SessionViewModel : ObservableObject, IDisposable
             System.Diagnostics.Process.Start("explorer.exe", Session.WorkingFolder);
     }
 
+    /// <summary>
+    /// Applies a CSM shell-integration payload (OSC 9001) emitted by the running program.
+    /// Recognised keys: <c>color</c> (#rrggbb), <c>git-branch</c>, <c>git-dirty</c> (0/1),
+    /// <c>title</c>. Unknown keys are ignored. Useful for SSH overlays whose remote
+    /// state CSM cannot inspect locally.
+    /// </summary>
+    public void ApplyShellIntegration(System.Collections.Generic.IReadOnlyDictionary<string, string> fields)
+    {
+        if (fields.TryGetValue("color", out var color) && IsValidHexColor(color))
+        {
+            Session.ColorOverride = color;
+            OnPropertyChanged(nameof(AccentColor));
+        }
+
+        if (fields.TryGetValue("git-branch", out var branch))
+        {
+            GitBranch = string.IsNullOrWhiteSpace(branch) ? null : branch;
+            GitInfoLoaded = true;
+        }
+
+        if (fields.TryGetValue("git-dirty", out var dirty))
+            GitIsDirty = dirty == "1" || string.Equals(dirty, "true", StringComparison.OrdinalIgnoreCase);
+
+        if (fields.TryGetValue("title", out var title) && !string.IsNullOrWhiteSpace(title))
+            Rename(title.Trim());
+    }
+
+    private static bool IsValidHexColor(string s)
+    {
+        if (string.IsNullOrEmpty(s) || s[0] != '#') return false;
+        if (s.Length != 4 && s.Length != 7 && s.Length != 9) return false;
+        for (int i = 1; i < s.Length; i++)
+            if (!Uri.IsHexDigit(s[i])) return false;
+        return true;
+    }
+
     public void RaiseAlert(string message, AlertType alertType = AlertType.InputRequired)
     {
         NeedsAttention = true;

--- a/src/CodeShellManager/ViewModels/SessionViewModel.cs
+++ b/src/CodeShellManager/ViewModels/SessionViewModel.cs
@@ -71,6 +71,15 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     private readonly CancellationTokenSource _gitPollCts = new();
 
+    // Set by ApplyShellIntegration when the running program pushes git-branch
+    // or git-dirty via OSC 9001. Tells the local poller to stand down: the
+    // program is sourcing its own git state (e.g. `nexus ssh` into a container
+    // whose /workspace branch is unrelated to the host CWD) and the local
+    // poll would otherwise clobber the OSC value every 10s. Sticky for the
+    // lifetime of the session — once a program declares itself the source of
+    // truth, we trust it.
+    private bool _gitOverriddenByOsc;
+
     public SessionViewModel(ShellSession session)
     {
         Session = session;
@@ -81,7 +90,7 @@ public partial class SessionViewModel : ObservableObject, IDisposable
 
     public async Task RefreshGitInfoAsync()
     {
-        if (Session.IsRemote) return;
+        if (Session.IsRemote || _gitOverriddenByOsc) return;
         var (branch, isDirty) = await GitService.GetGitInfoAsync(Session.WorkingFolder);
         GitBranch = branch;
         GitIsDirty = isDirty;
@@ -147,10 +156,14 @@ public partial class SessionViewModel : ObservableObject, IDisposable
         {
             GitBranch = string.IsNullOrWhiteSpace(branch) ? null : branch;
             GitInfoLoaded = true;
+            _gitOverriddenByOsc = true;
         }
 
         if (fields.TryGetValue("git-dirty", out var dirty))
+        {
             GitIsDirty = dirty == "1" || string.Equals(dirty, "true", StringComparison.OrdinalIgnoreCase);
+            _gitOverriddenByOsc = true;
+        }
 
         if (fields.TryGetValue("title", out var title) && !string.IsNullOrWhiteSpace(title))
             Rename(title.Trim());

--- a/tests/CodeShellManager.Tests/AlertDetectorStripAnsiTests.cs
+++ b/tests/CodeShellManager.Tests/AlertDetectorStripAnsiTests.cs
@@ -1,0 +1,42 @@
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// <see cref="AlertDetector.StripAnsi"/> is what the prompt regexes actually see. OSC strings
+/// (title changes, hyperlinks, CSM's own OSC 9001) may end in either BEL or ST (<c>ESC \</c>);
+/// both forms must be removed, or their payload leaks into prompt matching.
+/// </summary>
+public class AlertDetectorStripAnsiTests
+{
+    private static readonly string Esc = ((char)0x1b).ToString();
+    private static readonly string Bel = ((char)0x07).ToString();
+    private static readonly string St = Esc + "\\";
+
+    [Fact]
+    public void StripAnsi_OscTerminatedWithBel_IsRemoved()
+        => Assert.Equal("before after",
+            AlertDetector.StripAnsi("before " + Esc + "]0;window title" + Bel + "after"));
+
+    [Fact]
+    public void StripAnsi_OscTerminatedWithSt_IsRemoved()
+        => Assert.Equal("before after",
+            AlertDetector.StripAnsi("before " + Esc + "]9001;color=#a6e3a1;title=demo?" + St + "after"));
+
+    [Fact]
+    public void StripAnsi_StTerminatedOsc_DoesNotSwallowFollowingOutputUpToLaterBel()
+    {
+        // With a BEL-only regex the lazy match runs from the first OSC through the real text
+        // to the BEL that ends the *second* OSC — deleting "Do you want to proceed?" from what
+        // the prompt regex sees.
+        string raw = Esc + "]9001;git-branch=main" + St
+                   + "Do you want to proceed?"
+                   + Esc + "]0;window title" + Bel;
+        Assert.Equal("Do you want to proceed?", AlertDetector.StripAnsi(raw));
+    }
+
+    [Fact]
+    public void StripAnsi_CsiWithPrivateMarker_IsRemoved()
+        => Assert.Equal("x", AlertDetector.StripAnsi(Esc + "[?25hx"));
+}

--- a/tests/CodeShellManager.Tests/ShellIntegrationPayloadTests.cs
+++ b/tests/CodeShellManager.Tests/ShellIntegrationPayloadTests.cs
@@ -1,0 +1,102 @@
+using CodeShellManager.Services;
+using Xunit;
+
+namespace CodeShellManager.Tests;
+
+/// <summary>
+/// Tests for <see cref="ShellIntegrationPayload"/> — the WPF-free rules behind OSC 9001.
+/// The values arrive from whatever program is printing to the terminal (a remote host,
+/// a `cat` of a file, a hook), so every field is treated as untrusted input.
+/// </summary>
+public class ShellIntegrationPayloadTests
+{
+    // ---- color ---------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("#abc", "#abc")]
+    [InlineData("#a6e3a1", "#a6e3a1")]
+    [InlineData("#A6E3A1", "#A6E3A1")]
+    [InlineData("#a6e3a180", "#80a6e3a1")]   // #rrggbbaa (integrator) → #aarrggbb (WPF)
+    public void TryNormalizeColor_ValidHex_ReturnsWpfForm(string input, string expected)
+    {
+        Assert.True(ShellIntegrationPayload.TryNormalizeColor(input, out var wpf));
+        Assert.Equal(expected, wpf);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("red")]
+    [InlineData("rgb(1,2,3)")]
+    [InlineData("a6e3a1")]        // missing '#'
+    [InlineData("#a6e3a")]        // 5 digits
+    [InlineData("#a6e3a1f")]      // 7 digits
+    [InlineData("#gggggg")]       // not hex
+    [InlineData("#a6e3a1;title=x")]
+    public void TryNormalizeColor_Invalid_ReturnsFalse(string input)
+    {
+        Assert.False(ShellIntegrationPayload.TryNormalizeColor(input, out var wpf));
+        Assert.Null(wpf);
+    }
+
+    // ---- git-dirty -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("", false)]
+    [InlineData("yes", false)]    // only 1/true count as dirty
+    public void ParseDirty(string input, bool expected)
+        => Assert.Equal(expected, ShellIntegrationPayload.ParseDirty(input));
+
+    // ---- title ---------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("my-repo", "my-repo")]
+    [InlineData("  padded  ", "padded")]
+    [InlineData("tab\there", "tabhere")]                  // control chars stripped
+    [InlineData("esc\u001b[31mred", "esc[31mred")]        // ESC stripped, printable remainder kept
+    [InlineData("multi\r\nline", "multiline")]
+    [InlineData("ünïcödé ⎇ ok", "ünïcödé ⎇ ok")]          // non-ASCII printable is fine
+    public void SanitizeTitle_Printable_TrimsAndStripsControls(string input, string expected)
+        => Assert.Equal(expected, ShellIntegrationPayload.SanitizeTitle(input));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\u0007\u001b")]  // nothing printable left
+    public void SanitizeTitle_NothingUsable_ReturnsNull(string input)
+        => Assert.Null(ShellIntegrationPayload.SanitizeTitle(input));
+
+    [Fact]
+    public void SanitizeTitle_LongTitle_IsCappedAtMaxTitleLength()
+    {
+        string input = new('x', ShellIntegrationPayload.MaxTitleLength + 50);
+        string? result = ShellIntegrationPayload.SanitizeTitle(input);
+        Assert.NotNull(result);
+        Assert.Equal(ShellIntegrationPayload.MaxTitleLength, result!.Length);
+    }
+
+    [Fact]
+    public void SanitizeTitle_CapDoesNotSplitSurrogatePair()
+    {
+        // Fill up to one char short of the cap, then a 2-char emoji straddling the boundary.
+        string input = new string('x', ShellIntegrationPayload.MaxTitleLength - 1) + "😀";
+        string? result = ShellIntegrationPayload.SanitizeTitle(input);
+        Assert.NotNull(result);
+        Assert.False(char.IsHighSurrogate(result![^1]), "cap must not leave a dangling high surrogate");
+    }
+
+    // ---- git-branch ----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("main", "main")]
+    [InlineData(" feat/x ", "feat/x")]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData("a\u001bb", "ab")]
+    public void SanitizeBranch(string input, string? expected)
+        => Assert.Equal(expected, ShellIntegrationPayload.SanitizeBranch(input));
+}


### PR DESCRIPTION
Supersedes #19 (`feat/osc-shell-integration`, @martin-ottosen), rebuilt on current `main`. The original branch was 114 commits behind and no longer mergeable; the design is unchanged, the plumbing was redone where main had moved.

### What this is

Programs running inside a CSM terminal can push session state to the host UI with a custom OSC sequence:

```
ESC ] 9001 ; color=#a6e3a1 ; git-branch=feat/foo ; git-dirty=1 ; title=my-repo  ST
```

- `color` — overrides the session accent (sidebar stripe + active ring), persisted
- `git-branch` / `git-dirty` — sets the sidebar git label, and the local poller stands down for the session
- `title` — renames the session, persisted

Public integrator reference with bash/PowerShell/Python/Node/Rust/Go snippets: `docs/shell-integration.md`.

### What was kept from #19 (cherry-picked, original authorship preserved)

- OSC 9001 handler in `terminal-init.js`, `TerminalBridge.ShellIntegrationReceived`, `SessionViewModel.ApplyShellIntegration`
- git-poller stand-down once a program has pushed git info
- `#rrggbbaa` → `#aarrggbb` conversion for WPF
- docs + README cross-link

### What was dropped and why

- **MainWindow repaint hunks** — main now repaints stripe and ring on every `AccentColor` change (worktree-sibling colouring). Merging them produced a duplicate `case` label. Only the bridge→VM wiring survives.
- **StateService `SemaphoreSlim` + `IDisposable`** — superseded by the atomic write + `SaveGate` from #88.

### What was added

- **All OSC values are treated as untrusted** (they come from whatever prints to the terminal, and `color`/`title` land in `state.json`). Validation moved into a WPF-free `Services/ShellIntegrationPayload`: title capped at 80 chars, control characters stripped, empty-after-cleanup ignored; branch stripped the same way. 25 unit tests.
- **`AlertDetector` now strips `ESC \`-terminated OSC.** Its regex only knew BEL, so an ST-terminated OSC (every example in the docs) either leaked its payload into prompt matching or lazily swallowed real output up to the next BEL. Pre-existing bug, made hot by this feature. 4 tests.
- **"Reset accent color"** in the sidebar context menu whenever an override exists — OSC is the only writer of `ColorOverride` and it survives sleep/wake/restart, so there was no way back.
- **Folder edit re-enables the git poller** (`ReloadGitInfoAsync` clears the stand-down flag).
- **Debounced save** (`MainViewModel.SaveStateDebounced`, 500ms idle) instead of a `state.json` write per emission.
- **`;` in values** documented as a limitation (the one unanswered review comment on #19).

### Test plan

- [x] `dotnet build` clean, `dotnet test` 343/343 (32 new)
- [x] `printf '\e]9001;color=#a6e3a1\e\'` — stripe + ring go green; right-click → "Reset accent color" appears and reverts
- [x] `printf '\e]9001;git-branch=feat/foo;git-dirty=1\e\'` — sidebar shows `⎇ feat/foo*`; `cd` elsewhere no longer changes it
- [x] `printf '\e]9001;title=Demo\e\'` — title becomes `Demo`, survives restart
- [x] Run a Claude session with a prompt hook emitting OSC 9001 every prompt — no alert false-positives, no `state.json` churn beyond one write per burst
- [x] Edit session → change folder → git label follows the new folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BEpUD83C7UHLMxNm8XByu
