### PR TITLE
docs(chocolatey): moderation cleared; add the MIT line the moderator asked for

### DIFF
--- a/.chocolatey/codeshellmanager.nuspec
+++ b/.chocolatey/codeshellmanager.nuspec
@@ -36,6 +36,10 @@
 
 * Windows 10 (1903+) or Windows 11
 * [Microsoft Edge WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/) (pre-installed on Windows 11)
+
+## License
+
+CodeShellManager is open source under the [MIT License](https://github.com/umage-ai/CodeShellManager/blob/main/LICENSE).
 ]]></description>
     <releaseNotes>https://github.com/umage-ai/CodeShellManager/releases/tag/v__VERSION__</releaseNotes>
   </metadata>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,28 +663,33 @@ The tag value overrides the csproj `<Version>` at publish time (`-p:Version=` fl
 # 1. wait for CI / Release to finish and the GitHub Release to exist
 # 2. then dispatch the mirrors by hand
 gh workflow run winget.yml     -f tag=vX.Y.Z
-gh workflow run chocolatey.yml -f tag=vX.Y.Z   # ONLY if not blocked — see below
+gh workflow run chocolatey.yml -f tag=vX.Y.Z
 # 3. watch them — they fail independently of CI and nothing else will tell you
 ```
 
 To make it genuinely automatic, CI / Release would have to create the Release with a PAT rather than `GITHUB_TOKEN`.
 
-**Chocolatey is currently blocked on moderation — do not dispatch it.** The v0.5.0
-submission is still awaiting *human* review on community.chocolatey.org. Automated
-verification passes (last resubmission 03 Sep 2026, the #112 icon-CDN + WebView2 round), but
-until a moderator approves it, newer versions cannot be submitted on top of it. Dispatching
-`chocolatey.yml` for v0.6.0 or v0.7.0 does not queue them behind the review — it fails.
+**Chocolatey moderation: cleared 08 Sep 2026.** The v0.5.0 submission — the package's first —
+sat in the human review queue from May, which is why the listing stayed on 0.5.0 through two
+releases and why its download counter (44) reflects the moderation pipeline more than users:
+a package under moderation isn't listed in search and can't be installed without an explicit
+`--version`.
 
-Two consequences worth knowing before reading the numbers:
+That is now resolved and dispatching works normally. Two things learned from that first
+submission, both worth keeping:
 
-- `community.chocolatey.org/packages/codeshellmanager` still serves **v0.5.0**, and will
-  keep doing so however many tags get pushed here.
-- A package under moderation is not listed in search and cannot be installed without an
-  explicit `--version`, so its download counter reflects the moderation pipeline more than
-  it reflects users.
+- **A first submission to a new package id goes to human review, and can take months.** Only
+  the *first* one; subsequent versions from a maintainer with an approved package auto-verify.
+  Plan the first release of any new id accordingly.
+- **Don't back-fill skipped versions.** Only the newest matters to `choco install`; submitting
+  0.6.0 and 0.7.0 now would be pure churn. Go straight to the current tag.
 
-Check the package page for the "awaiting moderation" banner before dispatching. Once it
-clears, the backlog is submitted per tag.
+The moderator explicitly endorsed the WebView2 approach from #112 — probing all three
+EdgeUpdate registry keys and *warning* with a symptom and remedy rather than hard-failing or
+force-installing. They floated `<dependency id="webview2-runtime" />` as an alternative and
+then argued against it themselves, since it forces an install on machines that already have
+the runtime (all of Windows 11). Keep the warning; do not add the dependency unless
+blank-terminal reports actually show up.
 
 ### Download counts: GitHub's number already contains the other two
 


### PR DESCRIPTION
The v0.5.0 submission — the package's first — was approved on 08 Sep 2026 after sitting in human review since May.

**CLAUDE.md told the next reader not to dispatch `chocolatey.yml`.** That is now wrong, and left as-is the next release would have silently skipped the mirror.

Recorded rather than deleted, because two facts from that first submission are reusable:

- A **first** submission to a new package id goes to human review and can take months. Only the first — later versions from a maintainer with an approved package auto-verify. That is a release-planning fact for any future package id.
- **Don't back-fill 0.6.0/0.7.0.** Only the newest version matters to `choco install`; go straight to the current tag.

It also explains the download counter (44): the package spent its whole life unlisted and un-installable without an explicit `--version`.

## The moderator's two points

**WebView2 dependency** — they raised `<dependency id="webview2-runtime" />` and then argued against it themselves, since it forces an install on machines that already ship the runtime (all of Windows 11). Keeping #112's warn-with-symptom-and-remedy approach, which is what they praised. Recorded as a decision so it isn't relitigated.

**Licensing** — added. `licenseUrl` already pointed at the repo LICENSE, but the description never said so, so the page didn't read as open source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDsEfog5kVkT5NmX1Ya5be